### PR TITLE
chore(home-ops): Talos 1.13.7 + Kubernetes 1.36.2

### DIFF
--- a/kubernetes/bootstrap/talos/omni-home-ops.yaml
+++ b/kubernetes/bootstrap/talos/omni-home-ops.yaml
@@ -2,10 +2,10 @@ kind: Cluster
 name: home-ops
 kubernetes:
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-  version: v1.33.3
+  version: v1.36.2
 talos:
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-  version: v1.10.5
+  version: v1.13.7
 patches:
   - file: patches/base/global/cluster.yaml
   - file: patches/base/global/disks.yaml


### PR DESCRIPTION
## Summary
- Bump home-ops Omni cluster Talos installer to **v1.13.7**
- Bump Kubernetes/kubelet to **v1.36.2**

## Test plan
- [ ] `omnictl cluster template validate -f omni-home-ops.yaml`
- [ ] Review Omni sync/upgrade plan before applying
- [ ] Confirm node disks/NICs/extensions still valid on Talos 1.13

Made with [Cursor](https://cursor.com)