### PR TITLE
chore(mgmt): Talos 1.13.7 + Kubernetes 1.36.2

### DIFF
--- a/kubernetes/bootstrap/talos/omni-mgmt.yaml
+++ b/kubernetes/bootstrap/talos/omni-mgmt.yaml
@@ -2,10 +2,10 @@ kind: Cluster
 name: management
 kubernetes:
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-  version: v1.33.3
+  version: v1.36.2
 talos:
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-  version: v1.10.6
+  version: v1.13.7
 patches:
   - file: patches/base/global/cluster.yaml
   - file: patches/base/global/kubelet.yaml


### PR DESCRIPTION
## Summary
- Bump management Omni cluster Talos installer to **v1.13.7**
- Bump Kubernetes/kubelet to **v1.36.2**

## Test plan
- [ ] `mise run omni-validate`
- [ ] Review Omni sync/upgrade plan before applying
- [ ] Upgrade management cluster first, verify nodes Ready, then proceed to workloads

Made with [Cursor](https://cursor.com)