### PR TITLE
chore(argo): bump platform chart targetRevisions

### DIFF
--- a/kubernetes/argo/apps/argo-system/argo-cd.yaml
+++ b/kubernetes/argo/apps/argo-system/argo-cd.yaml
@@ -13,7 +13,7 @@ spec:
   sources:
     - repoURL: ghcr.io/argoproj/argo-helm
       chart: argo-cd
-      targetRevision: 8.2.4
+      targetRevision: 10.2.1
       helm:
         releaseName: argo-cd
         valueFiles:

--- a/kubernetes/argo/apps/cert-manager/cert-manager.yaml
+++ b/kubernetes/argo/apps/cert-manager/cert-manager.yaml
@@ -11,7 +11,7 @@ spec:
   sources:
     - repoURL: https://charts.jetstack.io
       chart: cert-manager
-      targetRevision: v1.18.2 
+      targetRevision: v1.21.0
       helm:
         releaseName: cert-manager
         valueFiles:

--- a/kubernetes/argo/apps/kube-system/cilium/cilium.yaml
+++ b/kubernetes/argo/apps/kube-system/cilium/cilium.yaml
@@ -11,7 +11,7 @@ spec:
   sources:
     - repoURL: https://helm.cilium.io
       chart: cilium
-      targetRevision: 1.18.0
+      targetRevision: 1.19.6
       helm:
         releaseName: cilium
         valueFiles:

--- a/kubernetes/argo/apps/kube-system/coredns/coredns.yaml
+++ b/kubernetes/argo/apps/kube-system/coredns/coredns.yaml
@@ -11,7 +11,7 @@ spec:
   sources:
     - repoURL: ghcr.io/coredns/charts
       chart: coredns
-      targetRevision: 1.43.0
+      targetRevision: 1.46.2
       helm:
         releaseName: coredns
         valueFiles:

--- a/kubernetes/argo/apps/kube-system/spegel/spegel.yaml
+++ b/kubernetes/argo/apps/kube-system/spegel/spegel.yaml
@@ -11,7 +11,7 @@ spec:
   sources:
     - repoURL: ghcr.io/spegel-org/helm-charts
       chart: spegel
-      targetRevision: 0.3.0
+      targetRevision: 0.7.4
       helm:
         releaseName: spegel
         valueFiles:

--- a/kubernetes/argo/apps/longhorn-system/longhorn.yaml
+++ b/kubernetes/argo/apps/longhorn-system/longhorn.yaml
@@ -11,7 +11,7 @@ spec:
   sources:
     - repoURL: https://charts.longhorn.io
       chart: longhorn
-      targetRevision: 1.9.1
+      targetRevision: 1.12.0
       helm:
         valueFiles:
           - $repo/kubernetes/apps/longhorn-system/values.yaml


### PR DESCRIPTION
## Summary
- cilium `1.18.0` → `1.19.6`
- coredns `1.43.0` → `1.46.2`
- argo-cd `8.2.4` → `10.2.1`
- cert-manager `v1.18.2` → `v1.21.0`
- longhorn `1.9.1` → `1.12.0`
- spegel `0.3.0` → `0.7.4`

Aligns Argo apps with current helmfile pins / latest stables. external-secrets major bump is separate.

## Test plan
- [ ] Diff Argo apps after sync and review value compatibility
- [ ] Verify Cilium Gateway API + L2 announcements still healthy
- [ ] Verify Longhorn volumes and Argo CD UI after chart upgrade

Made with [Cursor](https://cursor.com)