### PR TITLE
chore(gateway-api): bump to v1.6.1

### DIFF
--- a/kubernetes/apps/kube-system/cilium/kustomization.yaml
+++ b/kubernetes/apps/kube-system/cilium/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-- https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
+- https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
 - ./ipv4-pool.yaml
 - ./cilium_l2_accouncement.yaml
 - ./gateway-api

--- a/kubernetes/system/gateway-api/kustomization.yaml
+++ b/kubernetes/system/gateway-api/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-- https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
+- https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml


### PR DESCRIPTION
## Summary
- Update Gateway API standard-install manifests from **v1.3.0** to **v1.6.1** in system and Cilium kustomizations

## Test plan
- [ ] Apply/sync and confirm Gateway/HTTPRoute CRDs upgrade cleanly
- [ ] Smoke-test internal and external gateways

Made with [Cursor](https://cursor.com)