### PR TITLE
chore(mise): bump kubectl, jq, and 1Password CLI

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -9,11 +9,11 @@ cluster = 'default'
 [tools]
 "aqua:siderolabs/talos" = "1.13.7"
 "aqua:siderolabs/omni/omnictl" = "1.9.3"
-"aqua:kubernetes/kubectl" = "1.33.2"
+"aqua:kubernetes/kubectl" = "1.36.2"
 "aqua:helmfile/helmfile" = "1.7.1"
 "aqua:cilium/cilium-cli" = "0.19.7"
-"aqua:jqlang/jq" = "1.8.1"
-"aqua:1password/cli" = "v2.31.1"
+"aqua:jqlang/jq" = "1.8.2"
+"aqua:1password/cli" = "v2.38.1"
 "aqua:kubevirt/kubevirt/virtctl" = "v1.8.4"
 
 [tasks.omni-validate]


### PR DESCRIPTION
## Summary
- kubectl `1.33.2` → `1.36.2` (match cluster target)
- jq `1.8.1` → `1.8.2`
- 1Password CLI `v2.31.1` → `v2.38.1`

## Test plan
- [ ] `mise install`
- [ ] `kubectl version --client`
- [ ] `op --version`

Made with [Cursor](https://cursor.com)