### PR TITLE
chore(external-secrets): bump chart to 2.8.0 (major)

### DIFF
--- a/kubernetes/argo/apps/external-secrets/external-secrets.yaml
+++ b/kubernetes/argo/apps/external-secrets/external-secrets.yaml
@@ -11,7 +11,7 @@ spec:
   sources:
     - repoURL: https://charts.external-secrets.io
       chart: external-secrets
-      targetRevision: 0.18.2 
+      targetRevision: 2.8.0
       helm:
         releaseName: external-secrets
         valueFiles:


### PR DESCRIPTION
## Summary
- external-secrets chart `0.18.2` → `2.8.0` (**major**)

Separated because CRDs/API and values may need manual review.

## Test plan
- [ ] Review upstream upgrade notes for 0.x → 2.x
- [ ] Diff current values against chart defaults
- [ ] Confirm SecretStore/ExternalSecret resources still reconcile after upgrade

Made with [Cursor](https://cursor.com)