### PR TITLE
chore: pin kubectl and kubelogin to cluster Kubernetes version

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -13,13 +13,14 @@ kube_context_mgmt = 'management'
 [tools]
 "aqua:siderolabs/talos" = "1.13.7"
 "aqua:siderolabs/omni/omnictl" = "1.9.3"
-"aqua:kubernetes/kubectl" = "1.36.2"
+# Keep kubectl + kubelogin on the cluster Kubernetes version (kubernetes/versions.env).
+"aqua:kubernetes/kubectl" = "{{env.KUBERNETES_VERSION}}"
 "aqua:helm/helm" = "3.18.6"
 "aqua:cilium/cilium-cli" = "0.19.7"
 "aqua:jqlang/jq" = "1.8.2"
 "aqua:1password/cli" = "v2.35.0"
 "aqua:kubevirt/kubevirt/virtctl" = "v1.8.4"
-"aqua:int128/kubelogin" = "1.36.2"
+"aqua:int128/kubelogin" = "{{env.KUBERNETES_VERSION}}"
 "aqua:yannh/kubeconform" = "0.6.7"
 
 [tasks.manifests-render]

--- a/kubernetes/versions.env
+++ b/kubernetes/versions.env
@@ -1,9 +1,12 @@
 # Chart and CRD versions (bootstrap + day-2 alignment)
 #
 # Pinned versions used by Omni bootstrap render (mise run manifests-render).
-# Keep aligned with Argo CD Application targetRevision under kubernetes/argo/apps/.
+# Keep aligned with Argo CD Application targetRevision under kubernetes/argo/.
 # Renovate updates this file via the regex custom manager in renovate.json.
 
+# Cluster Kubernetes version (Omni kubernetes.version in omni-*.yaml; also pins kubectl + kubelogin).
+# renovate: datasource=github-releases depName=kubernetes/kubernetes extractVersion=^v(?<version>.*)$
+KUBERNETES_VERSION=1.36.2
 # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
 GATEWAY_API_VERSION=v1.6.1
 # renovate: datasource=helm depName=cilium registryUrl=https://helm.cilium.io

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
         "/kubernetes/versions\\.env$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: registryUrl=(?<registryUrl>\\S+))?\\n[A-Z0-9_]+=(?<currentValue>.+)"
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: registryUrl=(?<registryUrl>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?\\n[A-Z0-9_]+=(?<currentValue>.+)"
       ]
     }
   ],
@@ -46,6 +46,22 @@
       "description": "Group Gateway API CRD bumps",
       "matchPackageNames": ["kubernetes-sigs/gateway-api"],
       "groupName": "gateway-api"
+    },
+    {
+      "description": "Pin kubectl + kubelogin to KUBERNETES_VERSION in versions.env (not independent mise bumps)",
+      "matchManagers": ["mise"],
+      "matchPackageNames": [
+        "aqua:kubernetes/kubectl",
+        "kubernetes/kubectl",
+        "aqua:int128/kubelogin",
+        "int128/kubelogin"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Cluster Kubernetes client pin (kubectl + kubelogin via mise env)",
+      "matchPackageNames": ["kubernetes/kubernetes"],
+      "groupName": "kubernetes"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `KUBERNETES_VERSION=1.36.2` in `kubernetes/versions.env` (matches Omni/cluster Kubernetes)
- Point mise `kubectl` and `kubelogin` at `{{env.KUBERNETES_VERSION}}` so they stay locked together
- Disable independent mise bumps for those tools; Renovate manages the shared pin via versions.env (`extractVersion` supported)

## Test plan
- [ ] `mise ls` shows kubectl and kubelogin both at 1.36.2
- [ ] `mise exec -- kubectl version --client` reports v1.36.2
- [ ] Confirm Renovate does not open a kubelogin-only bump (e.g. to 1.36.3)


Made with [Cursor](https://cursor.com)