### PR TITLE
chore(deps): bump helm to v4.2.3

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -15,7 +15,7 @@ kube_context_mgmt = 'management'
 "aqua:siderolabs/omni/omnictl" = "1.9.3"
 # Keep kubectl + kubelogin on the cluster Kubernetes version (kubernetes/versions.env).
 "aqua:kubernetes/kubectl" = "{{env.KUBERNETES_VERSION}}"
-"aqua:helm/helm" = "3.18.6"
+"aqua:helm/helm" = "4.2.3"
 "aqua:cilium/cilium-cli" = "0.19.7"
 "aqua:jqlang/jq" = "1.8.2"
 "aqua:1password/cli" = "v2.35.0"


### PR DESCRIPTION
## Summary
- Bump `aqua:helm/helm` from 3.18.6 → **4.2.3** (supersedes Renovate #34 / #35)
- Verified `mise run manifests-render` (cilium, coredns, spegel, argo-cd templates) succeeds with Helm 4

## Test plan
- [x] `mise exec -- helm version` reports v4.2.3
- [x] `mise run manifests-render` completes successfully
- [ ] CI kubeconform / omni-validate still green


Made with [Cursor](https://cursor.com)