### PR TITLE
chore(ci): bump actions/checkout to v7 and mise-action to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,9 @@ jobs:
     name: kubeconform
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
         with:
           cache: true
 
@@ -49,9 +49,9 @@ jobs:
     name: omni-validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: jdx/mise-action@v2
+      - uses: jdx/mise-action@v4
         with:
           cache: true
 


### PR DESCRIPTION
## Summary
- Combine Renovate [#42](https://github.com/wouterbouvy/home-ops/pull/42) (`actions/checkout` v4 → v7) and [#43](https://github.com/wouterbouvy/home-ops/pull/43) (`jdx/mise-action` v2 → v4)
- Avoids sequential conflicts on `.github/workflows/ci.yaml`

## Test plan
- [ ] CI `kubeconform` and `omni-validate` pass on this PR


Made with [Cursor](https://cursor.com)