### PR TITLE
chore(deps): bump Kubernetes to v1.36.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
             -summary \
             -strict \
             -ignore-missing-schemas \
-            -kubernetes-version 1.36.0 \
+            -kubernetes-version 1.36.3 \
             "${files[@]}" \
             /tmp/argo-home-ops.yaml \
             /tmp/argo-mgmt.yaml

--- a/kubernetes/bootstrap/talos/omni-home-ops.yaml
+++ b/kubernetes/bootstrap/talos/omni-home-ops.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 name: home-ops
 kubernetes:
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-  version: v1.36.2
+  version: v1.36.3
   manifests:
     - name: gateway-api
       file: manifests/gateway-api.yaml

--- a/kubernetes/bootstrap/talos/omni-mgmt.yaml
+++ b/kubernetes/bootstrap/talos/omni-mgmt.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 name: management
 kubernetes:
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-  version: v1.36.2
+  version: v1.36.3
 talos:
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
   version: v1.13.7

--- a/kubernetes/versions.env
+++ b/kubernetes/versions.env
@@ -6,7 +6,7 @@
 
 # Cluster Kubernetes version (Omni kubernetes.version in omni-*.yaml; also pins kubectl + kubelogin).
 # renovate: datasource=github-releases depName=kubernetes/kubernetes extractVersion=^v(?<version>.*)$
-KUBERNETES_VERSION=1.36.2
+KUBERNETES_VERSION=1.36.3
 # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
 GATEWAY_API_VERSION=v1.6.1
 # renovate: datasource=helm depName=cilium registryUrl=https://helm.cilium.io


### PR DESCRIPTION
## Summary
- Bump `KUBERNETES_VERSION` 1.36.2 → **1.36.3** (pins kubectl + kubelogin)
- Bump Omni `kubernetes.version` in `omni-home-ops.yaml` and `omni-mgmt.yaml` to **v1.36.3**
- Align CI `kubeconform -kubernetes-version` to 1.36.3
- Supersedes incomplete Renovate [#46](https://github.com/wouterbouvy/home-ops/pull/46) (versions.env only)

## Test plan
- [ ] CI `kubeconform` + `omni-validate` pass
- [ ] After merge, run `mise run omni-sync` on home-ops to apply the cluster upgrade
- [ ] Confirm nodes report `v1.36.3`


Made with [Cursor](https://cursor.com)