### PR TITLE
fix(mise): strip Helm 4 OCI Pulled/Digest lines from manifests

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -31,10 +31,11 @@ run = [
     "helm repo add cilium https://helm.cilium.io --force-update",
     "helm repo update cilium",
     "helm template cilium cilium/cilium --version \"${CILIUM_CHART_VERSION}\" --namespace kube-system --values ../../apps/kube-system/cilium/values.yaml > manifests/cilium.yaml",
-    "helm template coredns oci://ghcr.io/coredns/charts/coredns --version \"${COREDNS_CHART_VERSION}\" --namespace kube-system --values ../../apps/kube-system/coredns/values.yaml > manifests/coredns.yaml",
-    "helm template spegel oci://ghcr.io/spegel-org/helm-charts/spegel --version \"${SPEGEL_CHART_VERSION}\" --namespace kube-system --values ../../apps/kube-system/spegel/values.yaml > manifests/spegel.yaml",
+    # Helm 4 prints OCI Pulled/Digest lines to stdout; strip them so Omni gets valid YAML.
+    "helm template coredns oci://ghcr.io/coredns/charts/coredns --version \"${COREDNS_CHART_VERSION}\" --namespace kube-system --values ../../apps/kube-system/coredns/values.yaml | sed -e '/^Pulled:/d' -e '/^Digest:/d' > manifests/coredns.yaml",
+    "helm template spegel oci://ghcr.io/spegel-org/helm-charts/spegel --version \"${SPEGEL_CHART_VERSION}\" --namespace kube-system --values ../../apps/kube-system/spegel/values.yaml | sed -e '/^Pulled:/d' -e '/^Digest:/d' > manifests/spegel.yaml",
     """printf '%s\\n' '---' 'apiVersion: v1' 'kind: Namespace' 'metadata:' '  name: argo-system' > manifests/argo-cd.yaml""",
-    "helm template argo-cd oci://ghcr.io/argoproj/argo-helm/argo-cd --version \"${ARGOCD_CHART_VERSION}\" --namespace argo-system --values ../../apps/argo-system/values.yaml --include-crds >> manifests/argo-cd.yaml",
+    "helm template argo-cd oci://ghcr.io/argoproj/argo-helm/argo-cd --version \"${ARGOCD_CHART_VERSION}\" --namespace argo-system --values ../../apps/argo-system/values.yaml --include-crds | sed -e '/^Pulled:/d' -e '/^Digest:/d' >> manifests/argo-cd.yaml",
 ]
 dir = "kubernetes/bootstrap/talos"
 


### PR DESCRIPTION
## Summary
- Strip Helm 4 OCI `Pulled:` / `Digest:` stdout lines when rendering CoreDNS, Spegel, and Argo CD bootstrap manifests
- Fixes `omni-sync` failing with invalid JSON in KubernetesManifestGroups after the Helm 4 bump

## Test plan
- [x] `mise run omni-sync` succeeds after the strip
- [x] CI `omni-validate` / `kubeconform` pass on this PR


Made with [Cursor](https://cursor.com)