### PR TITLE
Enable SecureBoot and TPM LUKS for home-ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ talosconfig
 omniconfig
 1password-token
 HWIDs.md
+# SecureBoot install ISOs (large; regenerate via omnictl media download)
+secureboot-media/
 #temp
 /temp
 # Omni bootstrap: always render fresh via `mise run manifests-render`

--- a/.mise.toml
+++ b/.mise.toml
@@ -112,11 +112,9 @@ run = "omnictl cluster template delete -f omni-mgmt.yaml"
 dir = "kubernetes/bootstrap/talos"
 
 [tasks.omni-wipedisks]
-description = "Wipe Longhorn-related disks on home-ops nodes"
+description = "Wipe Longhorn NVMe disks on home-ops nodes (maintenance --insecure; set NODE_IPS)"
 run = [
-    "talosctl -n 10.0.8.3 wipe disk sda --drop-partition",
-    "talosctl -n 10.0.8.4 wipe disk sda --drop-partition",
-    "talosctl -n 10.0.8.5 wipe disk sda --drop-partition",
+    "bash -c 'for n in ${NODE_IPS:-10.0.99.162 10.0.99.167 10.0.99.172}; do echo Wiping nvme0n1 on $n; talosctl -n \"$n\" wipe disk nvme0n1 --insecure --drop-partition || true; done'",
 ]
 
 [tasks.omni-reboot]

--- a/README.md
+++ b/README.md
@@ -103,3 +103,24 @@ Point Cloudflare DNS for `*.home-ops.nl` at `10.0.8.120`. Only the Gateway **htt
 2. cert-manager chart (`-1`)
 3. Cloudflare ExternalSecret then ClusterIssuer (`cert-manager-config` wave `0`, issuer resource wave `1`)
 4. Gateway Certificate → HTTPS routes
+
+## SecureBoot / TPM
+
+Talos TPM disk encryption needs a **SecureBoot UKI** (`/.extra/tpm2-pcr-public-key.pem`). Non-SecureBoot images cannot enroll TPM LUKS keys.
+
+| Item | Value |
+|------|--------|
+| Omni media preset | `home-ops-sb-1.13.7` (SecureBoot, Talos **v1.13.7**, same extensions as [`omni-home-ops.yaml`](kubernetes/bootstrap/talos/omni-home-ops.yaml)) |
+| Image Factory schematic | `8b2c893977a01cb1fe2aa938ed38c989c89f51c4db5102d149b55550d12a2372` |
+| ISO (preferred) | `omnictl media download home-ops-sb-1.13.7 --format iso --talos-version v1.13.7 --output secureboot-media/` |
+| Install disk (template) | `/dev/sda` on each Machine in [`omni-home-ops.yaml`](kubernetes/bootstrap/talos/omni-home-ops.yaml) |
+
+Signing keys stay in Omni / Image Factory — do not commit private SecureBoot/PCR keys. Downloaded ISOs live under `secureboot-media/` (gitignored).
+
+**Prerequisites (firmware, per node):** TPM 2.0 on; clear/reset SecureBoot keys so UEFI is in **Setup Mode**; boot from USB written with the SecureBoot ISO. On bare metal, enroll keys from the ISO boot menu (`Enroll Secure Boot keys: auto`) — auto-enroll is VM-only by default.
+
+**Fresh SecureBoot install:** tear down with `mise run omni-reset`, boot all nodes from the SecureBoot ISO (maintenance + `secureBoot: true`), then `mise run omni-sync`. Omni selects `metal-installer-secureboot` from the machine security state — there is no template `secureboot:` flag. STATE, EPHEMERAL, and `u-longhorn` encrypt with **TPM** at install.
+
+**Cutover order:** SecureBoot ISO → `omni-sync` with TPM LUKS on STATE / EPHEMERAL / `u-longhorn`. Full steps: [`kubernetes/bootstrap/talos/SECUREBOOT-TPM.md`](kubernetes/bootstrap/talos/SECUREBOOT-TPM.md).
+
+**Ongoing:** Talos upgrades must use SecureBoot installer/UKI assets for the same schematic. Firmware dbx changes can break PCR 7 unlock — then set `tpm.options.pcrs: []` (PCR 11 only). Lost SecureBoot keys → TPM volumes will not unlock; recovery is wipe + re-encrypt.

--- a/kubernetes/bootstrap/talos/SECUREBOOT-TPM.md
+++ b/kubernetes/bootstrap/talos/SECUREBOOT-TPM.md
@@ -1,0 +1,79 @@
+# SecureBoot + TPM cutover (home-ops)
+
+## Why SecureBoot first
+
+Omni picks `factory.talos.dev/metal-installer-secureboot/<schematic>:v…` only when the machine reports `secureBoot: true` (from SecureBoot UKI / maintenance ISO). There is no cluster-template `secureboot:` flag — boot the SecureBoot ISO **before** `omni-sync`.
+
+## Phase 0 — Media
+
+```bash
+omnictl media preset list
+# home-ops-sb-1.13.7 — amd64, Talos 1.13.7, --secureboot
+
+mkdir -p secureboot-media
+omnictl media download home-ops-sb-1.13.7 --format iso --talos-version v1.13.7 \
+  --output secureboot-media/
+```
+
+ISO: `secureboot-media/home-ops-sb-1.13.7-v1.13.7-8b2c89.iso`  
+Schematic: `8b2c893977a01cb1fe2aa938ed38c989c89f51c4db5102d149b55550d12a2372`
+
+Firmware per node: TPM 2.0 on; clear SecureBoot keys → **Setup Mode**; USB first. On bare metal: Esc → **Enroll Secure Boot keys: auto**.
+
+## Phase 1 — Full cluster SecureBoot reinstall
+
+### 1. Tear down Omni cluster
+
+```bash
+mise run omni-reset
+```
+
+### 2. Boot all three from SecureBoot ISO (maintenance + `secureBoot: true`)
+
+Wipe **NVMe** before sync if a prior `u-longhorn` LUKS layout is present:
+
+```bash
+# from maintenance (--insecure); use each node's reachable IP
+talosctl -n <ip> wipe disk nvme0n1 --insecure --drop-partition
+```
+
+Verify:
+
+```bash
+omnictl get machinestatus -o yaml | rg 'hostname:|maintenance:|secureboot:'
+# all three: maintenance: true, secureboot: true
+```
+
+### 3. Sync
+
+Template pins `install.disk: /dev/sda`. STATE / EPHEMERAL use **TPM** with `options.pcrs: []` (PCR 11 only). `u-longhorn` is commented out until NVMe wipe post-bootstrap.
+
+If install fails with `TPM_RC_BAD_AUTH`: **Clear TPM** in UEFI on that node (required after failed seal attempts / DA lock), wipe system disk, re-boot SecureBoot ISO, then sync again.
+
+```bash
+mise run omni-sync
+mise run omni-bootstrap   # after nodes Ready
+```
+
+### 4. Verify
+
+```bash
+for n in 10.0.8.3 10.0.8.4 10.0.8.5; do
+  echo "=== $n ==="
+  talosctl -n "$n" get securitystate -o jsonpath='{.spec.secureBoot}{"\n"}'
+  talosctl -n "$n" ls /.extra
+done
+kubectl get nodes
+omnictl cluster status home-ops
+```
+
+## Encryption patches
+
+- [`disk-encryption.yaml`](patches/overlays/home-ops/controlplane/disk-encryption.yaml) — STATE / EPHEMERAL: `tpm: {}`
+- [`longhorn-uservolume.yaml`](patches/overlays/home-ops/controlplane/longhorn-uservolume.yaml) — `tpm: {}`
+
+## Recovery
+
+- Lost SecureBoot keys / SB disabled → TPM volumes will not unlock → wipe + re-encrypt.
+- Stale LUKS on NVMe after reset → wipe `nvme0n1` in maintenance before re-sync.
+- Omni denies out-of-band `talosctl upgrade` (`PermissionDenied`); use Omni + SecureBoot installers only.

--- a/kubernetes/bootstrap/talos/omni-home-ops.yaml
+++ b/kubernetes/bootstrap/talos/omni-home-ops.yaml
@@ -52,8 +52,13 @@ patches:
 kind: Workers
 machines:
 ---
+# install.disk: SATA system SSD (INTEL SSDSC2BB30). NVMe is reserved for u-longhorn.
+# SecureBoot installer is selected automatically when the machine reports secureBoot: true
+# (boot SecureBoot ISO into maintenance before mise run omni-sync).
 kind: Machine
 name: 5ea7c280-c43a-11e8-989b-7a47211d0c00 # Delta
+install:
+  disk: /dev/sda
 patches:
   - name: hostname
     inline:
@@ -73,6 +78,8 @@ patches:
 ---
 kind: Machine
 name: 3f1eae80-fa16-11e8-b2a5-75afac5e1000 # Echo
+install:
+  disk: /dev/sda
 patches:
   - name: hostname
     inline:
@@ -92,6 +99,8 @@ patches:
 ---
 kind: Machine
 name: 40210000-2edf-11e9-8a32-485d16011400 # Foxtrot
+install:
+  disk: /dev/sda
 patches:
   - name: hostname
     inline:

--- a/kubernetes/bootstrap/talos/patches/overlays/home-ops/controlplane/disk-encryption.yaml
+++ b/kubernetes/bootstrap/talos/patches/overlays/home-ops/controlplane/disk-encryption.yaml
@@ -4,7 +4,11 @@ name: STATE
 encryption:
   provider: luks2
   keys:
-    - nodeID: {}
+    # PCR 11 only (signed SecureBoot UKI policy). Empty pcrs skips PCR 7, which
+    # often mismatches across install vs reboot on OEM firmware (TPM_RC_BAD_AUTH).
+    - tpm:
+        options:
+          pcrs: []
       slot: 0
 ---
 apiVersion: v1alpha1
@@ -13,6 +17,7 @@ name: EPHEMERAL
 encryption:
   provider: luks2
   keys:
-    - nodeID: {}
+    - tpm:
+        options:
+          pcrs: []
       slot: 0
-      lockToState: true

--- a/kubernetes/bootstrap/talos/patches/overlays/home-ops/controlplane/longhorn-uservolume.yaml
+++ b/kubernetes/bootstrap/talos/patches/overlays/home-ops/controlplane/longhorn-uservolume.yaml
@@ -8,6 +8,7 @@ provisioning:
 encryption:
   provider: luks2
   keys:
-    - nodeID: {}
+    - tpm:
+        options:
+          pcrs: []
       slot: 0
-      lockToState: true


### PR DESCRIPTION
## Summary
- Document Omni SecureBoot ISO media and cutover steps for home-ops
- Pin each Machine `install.disk` to `/dev/sda` and switch STATE, EPHEMERAL, and `u-longhorn` to TPM with `pcrs: []` (PCR 11 only)
- Gitignore `secureboot-media/` and point `omni-wipedisks` at NVMe wipe helpers

## Test plan
- [ ] Confirm all nodes report `secureBoot: true` and `/.extra/tpm2-pcr-public-key.pem`
- [ ] Confirm STATE / EPHEMERAL / `u-longhorn` volumes are ready LUKS with TPM
- [ ] `mise run omni-validate` / CI green
- [ ] Rolling reboot still unlocks TPM volumes


Made with [Cursor](https://cursor.com)