### PR TITLE
Use Omni Cursor SA via 1Password; restore omni-wipedisks

### DIFF
--- a/.cursor/rules/omni-service-account.mdc
+++ b/.cursor/rules/omni-service-account.mdc
@@ -1,0 +1,13 @@
+---
+description: Use Omni Cursor service account for omnictl
+alwaysApply: true
+---
+
+# Omni authentication
+
+Use the Omni **Cursor** service account for all `omnictl` / Omni API work. Do not trigger personal browser/SideroV1 login.
+
+- mise loads credentials via [`scripts/omni-sa-env.sh`](scripts/omni-sa-env.sh) from 1Password (`op://k8s-secrets/dfmszcq3udnskcc4cvrzrr4hai`).
+- Prefer `mise exec -- omnictl …` or `mise run omni-*` so env is applied.
+- Never set `OMNICONFIG` in the same shell as `OMNI_ENDPOINT` / `OMNI_SERVICE_ACCOUNT_KEY`.
+- Do not print `OMNI_SERVICE_ACCOUNT_KEY` or commit it.

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,8 +1,13 @@
+redactions = ["OMNI_SERVICE_ACCOUNT_KEY"]
+
 [env]
-OMNICONFIG = "{{config_root}}/omniconfig"
+# Omni: Cursor service account via 1Password (scripts/omni-sa-env.sh). Do not set
+# OMNICONFIG alongside OMNI_ENDPOINT / OMNI_SERVICE_ACCOUNT_KEY — they conflict.
+OMNICONFIG = false
 KUBECONFIG = "{{config_root}}/kubeconfig"
 TALOSCONFIG = "{{config_root}}/talosconfig"
 _.file = "{{config_root}}/kubernetes/versions.env"
+_.source = { path = "{{config_root}}/scripts/omni-sa-env.sh", tools = true }
 
 [vars]
 cluster = 'default'

--- a/.mise.toml
+++ b/.mise.toml
@@ -112,9 +112,11 @@ run = "omnictl cluster template delete -f omni-mgmt.yaml"
 dir = "kubernetes/bootstrap/talos"
 
 [tasks.omni-wipedisks]
-description = "Wipe Longhorn NVMe disks on home-ops nodes (maintenance --insecure; set NODE_IPS)"
+description = "Wipe Longhorn-related disks on home-ops nodes"
 run = [
-    "bash -c 'for n in ${NODE_IPS:-10.0.99.162 10.0.99.167 10.0.99.172}; do echo Wiping nvme0n1 on $n; talosctl -n \"$n\" wipe disk nvme0n1 --insecure --drop-partition || true; done'",
+    "talosctl -n 10.0.8.3 wipe disk sda --drop-partition",
+    "talosctl -n 10.0.8.4 wipe disk sda --drop-partition",
+    "talosctl -n 10.0.8.5 wipe disk sda --drop-partition",
 ]
 
 [tasks.omni-reboot]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ flowchart TD
 ## Prerequisites
 
 - [mise](https://mise.jdx.dev/) (`mise install` from [`.mise.toml`](.mise.toml))
-- Local-only files (gitignored): `omniconfig`, `kubeconfig`, `talosconfig`, `HWIDs.md`
+- [1Password CLI](https://developer.1password.com/docs/cli/) signed in (`op`) — mise loads the Omni **Cursor** service account from vault `k8s-secrets` (item `Omni Cursor service account`) and sets `OMNI_ENDPOINT` / `OMNI_SERVICE_ACCOUNT_KEY` (see [`scripts/omni-sa-env.sh`](scripts/omni-sa-env.sh))
+- Local-only files (gitignored): `kubeconfig`, `talosconfig`, `HWIDs.md` (`omniconfig` is optional for personal UI/cli outside mise)
 
 ## Bootstrap (home-ops)
 

--- a/scripts/omni-sa-env.sh
+++ b/scripts/omni-sa-env.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Sourced by mise ([env] _.source). Loads the Cursor Omni service account from 1Password.
+# Requires: `op` signed in; item "Omni Cursor service account" in vault k8s-secrets.
+# OMNI_* env vars replace personal omniconfig auth — do not set OMNICONFIG alongside them.
+
+OMNI_SA_OP_REF="${OMNI_SA_OP_REF:-op://k8s-secrets/dfmszcq3udnskcc4cvrzrr4hai}"
+
+if ! command -v op >/dev/null 2>&1; then
+  echo "omni-sa-env: op CLI not found; skipping Omni service account load" >&2
+  return 0 2>/dev/null || exit 0
+fi
+
+export OMNI_ENDPOINT
+export OMNI_SERVICE_ACCOUNT_KEY
+OMNI_ENDPOINT="$(op read "${OMNI_SA_OP_REF}/OMNI_ENDPOINT")"
+OMNI_SERVICE_ACCOUNT_KEY="$(op read "${OMNI_SA_OP_REF}/OMNI_SERVICE_ACCOUNT_KEY")"
+unset OMNICONFIG


### PR DESCRIPTION
## Summary
- Load Omni Cursor service account credentials from 1Password in mise (`OMNI_ENDPOINT` / `OMNI_SERVICE_ACCOUNT_KEY`) instead of personal `omniconfig` auth
- Restore `omni-wipedisks` to the previous `sda` wipe targets (reverts the NVMe/`NODE_IPS` helper that landed in #52)

## Test plan
- [x] `mise exec -- omnictl cluster status home-ops` with `op` signed in
- [ ] Confirm `OMNICONFIG` is unset under mise and no browser login is prompted


Made with [Cursor](https://cursor.com)