### PR TITLE
Add rule: new branches for features

### DIFF
--- a/.cursor/rules/git-feature-branches.mdc
+++ b/.cursor/rules/git-feature-branches.mdc
@@ -1,0 +1,12 @@
+---
+description: Always use a new branch for new features
+alwaysApply: true
+---
+
+# Git branching
+
+Always create a **new branch** for new features or non-trivial changes. Do not commit directly to `main`.
+
+- Branch from up-to-date `main` (or the user-specified base).
+- Prefer a descriptive prefix such as `cursor/` or `chore/` / `feat/` matching existing repo style.
+- One concern per branch/PR when practical; do not pile unrelated work onto an existing feature branch unless the user asks.


### PR DESCRIPTION
## Summary
- Add always-on Cursor rule requiring a new branch for new features (no direct commits to `main`)

## Test plan
- [ ] Confirm the rule appears under `.cursor/rules/` and applies in Agent sessions


Made with [Cursor](https://cursor.com)