### PR TITLE
Rewrite SecureBoot/TPM docs as long-term ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,21 +107,6 @@ Point Cloudflare DNS for `*.home-ops.nl` at `10.0.8.120`. Only the Gateway **htt
 
 ## SecureBoot / TPM
 
-Talos TPM disk encryption needs a **SecureBoot UKI** (`/.extra/tpm2-pcr-public-key.pem`). Non-SecureBoot images cannot enroll TPM LUKS keys.
+home-ops runs **SecureBoot UKIs** with **TPM LUKS** on STATE, EPHEMERAL, and `u-longhorn` (`tpm.options.pcrs: []` = PCR 11 only). Omni picks the SecureBoot installer from machine `secureBoot: true` — there is no template flag.
 
-| Item | Value |
-|------|--------|
-| Omni media preset | `home-ops-sb-1.13.7` (SecureBoot, Talos **v1.13.7**, same extensions as [`omni-home-ops.yaml`](kubernetes/bootstrap/talos/omni-home-ops.yaml)) |
-| Image Factory schematic | `8b2c893977a01cb1fe2aa938ed38c989c89f51c4db5102d149b55550d12a2372` |
-| ISO (preferred) | `omnictl media download home-ops-sb-1.13.7 --format iso --talos-version v1.13.7 --output secureboot-media/` |
-| Install disk (template) | `/dev/sda` on each Machine in [`omni-home-ops.yaml`](kubernetes/bootstrap/talos/omni-home-ops.yaml) |
-
-Signing keys stay in Omni / Image Factory — do not commit private SecureBoot/PCR keys. Downloaded ISOs live under `secureboot-media/` (gitignored).
-
-**Prerequisites (firmware, per node):** TPM 2.0 on; clear/reset SecureBoot keys so UEFI is in **Setup Mode**; boot from USB written with the SecureBoot ISO. On bare metal, enroll keys from the ISO boot menu (`Enroll Secure Boot keys: auto`) — auto-enroll is VM-only by default.
-
-**Fresh SecureBoot install:** tear down with `mise run omni-reset`, boot all nodes from the SecureBoot ISO (maintenance + `secureBoot: true`), then `mise run omni-sync`. Omni selects `metal-installer-secureboot` from the machine security state — there is no template `secureboot:` flag. STATE, EPHEMERAL, and `u-longhorn` encrypt with **TPM** at install.
-
-**Cutover order:** SecureBoot ISO → `omni-sync` with TPM LUKS on STATE / EPHEMERAL / `u-longhorn`. Full steps: [`kubernetes/bootstrap/talos/SECUREBOOT-TPM.md`](kubernetes/bootstrap/talos/SECUREBOOT-TPM.md).
-
-**Ongoing:** Talos upgrades must use SecureBoot installer/UKI assets for the same schematic. Firmware dbx changes can break PCR 7 unlock — then set `tpm.options.pcrs: []` (PCR 11 only). Lost SecureBoot keys → TPM volumes will not unlock; recovery is wipe + re-encrypt.
+Ops reference (media preset, upgrades, re-provision, recovery): [`kubernetes/bootstrap/talos/SECUREBOOT-TPM.md`](kubernetes/bootstrap/talos/SECUREBOOT-TPM.md).

--- a/kubernetes/bootstrap/talos/SECUREBOOT-TPM.md
+++ b/kubernetes/bootstrap/talos/SECUREBOOT-TPM.md
@@ -1,79 +1,72 @@
-# SecureBoot + TPM cutover (home-ops)
+# SecureBoot + TPM (home-ops)
 
-## Why SecureBoot first
+Long-term ops notes for home-ops. SecureBoot and TPM LUKS are already in production on delta / echo / foxtrot.
 
-Omni picks `factory.talos.dev/metal-installer-secureboot/<schematic>:v…` only when the machine reports `secureBoot: true` (from SecureBoot UKI / maintenance ISO). There is no cluster-template `secureboot:` flag — boot the SecureBoot ISO **before** `omni-sync`.
+## Why SecureBoot is required
 
-## Phase 0 — Media
+Talos TPM encryption seals to a **PCR-11 signed UKI policy**. That public key only exists on SecureBoot UKIs (`/.extra/tpm2-pcr-public-key.pem`). Non-SecureBoot images cannot enroll or unlock TPM volumes.
+
+Omni selects `factory.talos.dev/metal-installer-secureboot/<schematic>:v…` when the machine reports `secureBoot: true`. There is **no** cluster-template `secureboot:` flag — nodes must boot SecureBoot media (or an already-installed SecureBoot UKI) so Omni sees that state.
+
+## Current configuration
+
+| Item | Value |
+|------|--------|
+| Omni media preset | `home-ops-sb-1.13.7` (SecureBoot, same extensions as [`omni-home-ops.yaml`](omni-home-ops.yaml)) |
+| Image Factory schematic | `8b2c893977a01cb1fe2aa938ed38c989c89f51c4db5102d149b55550d12a2372` |
+| Install disk | `/dev/sda` (SATA system SSD) on each Machine; NVMe reserved for Longhorn |
+| STATE / EPHEMERAL | LUKS2 + TPM, `options.pcrs: []` ([`disk-encryption.yaml`](patches/overlays/home-ops/controlplane/disk-encryption.yaml)) |
+| `u-longhorn` | LUKS2 + TPM, `options.pcrs: []` ([`longhorn-uservolume.yaml`](patches/overlays/home-ops/controlplane/longhorn-uservolume.yaml)) |
+
+`pcrs: []` means **PCR 11 only** (skip PCR 7). OEM firmware often changes PCR 7 across install vs reboot (`TPM_RC_BAD_AUTH`). Keep this unless you deliberately re-seal to PCR 7.
+
+Signing keys stay in Omni / Image Factory — never commit private SecureBoot or PCR keys. Downloaded ISOs go under `secureboot-media/` (gitignored).
+
+### Download SecureBoot ISO
 
 ```bash
 omnictl media preset list
-# home-ops-sb-1.13.7 — amd64, Talos 1.13.7, --secureboot
+# home-ops-sb-1.13.7 — amd64, --secureboot
 
 mkdir -p secureboot-media
 omnictl media download home-ops-sb-1.13.7 --format iso --talos-version v1.13.7 \
   --output secureboot-media/
 ```
 
-ISO: `secureboot-media/home-ops-sb-1.13.7-v1.13.7-8b2c89.iso`  
-Schematic: `8b2c893977a01cb1fe2aa938ed38c989c89f51c4db5102d149b55550d12a2372`
+Bump the preset / Talos version when upgrading; keep extensions aligned with [`omni-home-ops.yaml`](omni-home-ops.yaml).
 
-Firmware per node: TPM 2.0 on; clear SecureBoot keys → **Setup Mode**; USB first. On bare metal: Esc → **Enroll Secure Boot keys: auto**.
+## Upgrades
 
-## Phase 1 — Full cluster SecureBoot reinstall
+- Talos upgrades **must** use SecureBoot installer/UKI assets for the **same** Omni schematic (or a new SecureBoot schematic that replaces it deliberately).
+- Omni denies out-of-band `talosctl upgrade` (`PermissionDenied`); upgrade via Omni only.
+- After a schematic or major UKI change, confirm volumes still unlock (rolling reboot).
 
-### 1. Tear down Omni cluster
+## Re-provision / replace a node
 
-```bash
-mise run omni-reset
-```
+Firmware: TPM 2.0 on; SecureBoot keys enrolled (Setup Mode → enroll from ISO boot menu: **Enroll Secure Boot keys: auto** on bare metal).
 
-### 2. Boot all three from SecureBoot ISO (maintenance + `secureBoot: true`)
+1. Boot the node from the SecureBoot ISO into maintenance (`secureBoot: true`).
+2. If reusing disks with stale LUKS: wipe system disk and/or `nvme0n1` in maintenance (`talosctl -n <ip> wipe disk … --insecure --drop-partition`).
+3. `mise run omni-sync` (and `omni-bootstrap` if the cluster was torn down).
+4. If install fails with `TPM_RC_BAD_AUTH`: **Clear TPM** in UEFI, wipe system disk, re-boot SecureBoot ISO, sync again.
 
-Wipe **NVMe** before sync if a prior `u-longhorn` LUKS layout is present:
-
-```bash
-# from maintenance (--insecure); use each node's reachable IP
-talosctl -n <ip> wipe disk nvme0n1 --insecure --drop-partition
-```
-
-Verify:
+## Verify
 
 ```bash
-omnictl get machinestatus -o yaml | rg 'hostname:|maintenance:|secureboot:'
-# all three: maintenance: true, secureboot: true
-```
+omnictl cluster status home-ops
 
-### 3. Sync
-
-Template pins `install.disk: /dev/sda`. STATE / EPHEMERAL use **TPM** with `options.pcrs: []` (PCR 11 only). `u-longhorn` is commented out until NVMe wipe post-bootstrap.
-
-If install fails with `TPM_RC_BAD_AUTH`: **Clear TPM** in UEFI on that node (required after failed seal attempts / DA lock), wipe system disk, re-boot SecureBoot ISO, then sync again.
-
-```bash
-mise run omni-sync
-mise run omni-bootstrap   # after nodes Ready
-```
-
-### 4. Verify
-
-```bash
 for n in 10.0.8.3 10.0.8.4 10.0.8.5; do
   echo "=== $n ==="
   talosctl -n "$n" get securitystate -o jsonpath='{.spec.secureBoot}{"\n"}'
   talosctl -n "$n" ls /.extra
+  talosctl -n "$n" get volumestatus
 done
-kubectl get nodes
-omnictl cluster status home-ops
 ```
 
-## Encryption patches
-
-- [`disk-encryption.yaml`](patches/overlays/home-ops/controlplane/disk-encryption.yaml) — STATE / EPHEMERAL: `tpm: {}`
-- [`longhorn-uservolume.yaml`](patches/overlays/home-ops/controlplane/longhorn-uservolume.yaml) — `tpm: {}`
+Expect: `secureBoot: true`, `tpm2-pcr-public-key.pem` under `/.extra`, and STATE / EPHEMERAL / `u-longhorn` ready (LUKS).
 
 ## Recovery
 
-- Lost SecureBoot keys / SB disabled → TPM volumes will not unlock → wipe + re-encrypt.
-- Stale LUKS on NVMe after reset → wipe `nvme0n1` in maintenance before re-sync.
-- Omni denies out-of-band `talosctl upgrade` (`PermissionDenied`); use Omni + SecureBoot installers only.
+- Lost SecureBoot keys or SecureBoot disabled → TPM volumes will not unlock → wipe + re-encrypt (re-provision path above).
+- Stale Longhorn LUKS after reset → wipe `nvme0n1` in maintenance before re-syncing the UserVolumeConfig.
+- Firmware SecureBoot dbx updates that break unlock: keep `pcrs: []` (PCR 11 only); if still broken, wipe and re-enroll after Clear TPM.

--- a/kubernetes/bootstrap/talos/omni-home-ops.yaml
+++ b/kubernetes/bootstrap/talos/omni-home-ops.yaml
@@ -53,8 +53,8 @@ kind: Workers
 machines:
 ---
 # install.disk: SATA system SSD (INTEL SSDSC2BB30). NVMe is reserved for u-longhorn.
-# SecureBoot installer is selected automatically when the machine reports secureBoot: true
-# (boot SecureBoot ISO into maintenance before mise run omni-sync).
+# SecureBoot installer is selected when the machine reports secureBoot: true
+# (see SECUREBOOT-TPM.md).
 kind: Machine
 name: 5ea7c280-c43a-11e8-989b-7a47211d0c00 # Delta
 install:


### PR DESCRIPTION
## Summary
- Replace cutover-phase docs with steady-state SecureBoot/TPM ops (config, upgrades, re-provision, verify, recovery)
- Slim the README section to a short status blurb linking to that guide

## Test plan
- [ ] Skim README + `SECUREBOOT-TPM.md` for cutover leftovers
- [ ] Confirm links and media/schematic details still match the cluster


Made with [Cursor](https://cursor.com)