### PR TITLE
Add Authentik SSO and shared CloudNativePG

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Full mgmt bootstrap and testing still need Omni machine wiring later. When ready
 | Public domain | `home-ops.nl` |
 | External Gateway VIP | `10.0.8.120` |
 | Internal Gateway VIP | `10.0.8.110` |
-| Example hosts | `argocd.home-ops.nl`, `longhorn.home-ops.nl`, `grafana.home-ops.nl`, `hubble.home-ops.nl` |
+| Example hosts | `authentik.home-ops.nl`, `argocd.home-ops.nl`, `longhorn.home-ops.nl`, `grafana.home-ops.nl`, `hubble.home-ops.nl` |
 
 **TLS uses Let's Encrypt staging on purpose** while the lab is under active change:
 
@@ -100,12 +100,46 @@ Point Cloudflare DNS for `*.home-ops.nl` at `10.0.8.120`.
 
 **Gateway exposure:** the external Gateway `http` listener only allows routes from `kube-system` (`from: Same`) — use it for redirects/challenges in that namespace only. The **https** listener allows routes from **all** namespaces (`from: All`) and is the public entry for apps (`argocd`, `longhorn`, `grafana`, …). Prefer HTTPS HTTPRoutes for user-facing UIs.
 
+### Authentication (default deny)
+
+Public HTTPS UIs are protected by **Authentik** unless a route is explicitly documented as an exception.
+
+| Host | Protection |
+|------|------------|
+| `authentik.home-ops.nl` | Public IdP (login / OIDC / outpost callbacks) |
+| `argocd.home-ops.nl` | Native OIDC → Authentik (local admin disabled) |
+| `grafana.home-ops.nl` | Native OIDC → Authentik (login form / basic auth disabled) |
+| `hubble.home-ops.nl` | Authentik **proxy** outpost → Hubble UI |
+| `longhorn.home-ops.nl` | Authentik **proxy** outpost → Longhorn UI |
+
+**Add a new public UI:** prefer app-native OIDC against Authentik; if the app has no SSO, put an Authentik proxy provider in [`kubernetes/apps/authentik/blueprints.yaml`](kubernetes/apps/authentik/blueprints.yaml), attach it to the embedded outpost, and point the HTTPRoute at `authentik-server` in `authentik` (see Hubble/Longhorn + ReferenceGrant). Do **not** publish an unprotected HTTPRoute on the external Gateway.
+
+**1Password:** create item `authentik` in vault `k8s-secrets` with fields `SECRET_KEY`, `POSTGRES_PASSWORD`, `BOOTSTRAP_PASSWORD`, `BOOTSTRAP_EMAIL`, `ARGOCD_CLIENT_SECRET`, `GRAFANA_CLIENT_SECRET`. `POSTGRES_PASSWORD` is the Authentik DB role on the shared CNPG cluster. ExternalSecrets sync these into the cluster. OIDC client IDs are fixed (`argocd`, `grafana`).
+
+**Bootstrap admin:** log in once at `https://authentik.home-ops.nl` with `akadmin` / `BOOTSTRAP_PASSWORD`, then add your user to groups `ArgoCD Admins`, `Grafana Admins`, and/or `Home Ops Users`.
+
+**Break-glass (local admin):**
+
+- Argo CD: set `configs.cm.admin.enabled: "true"` in [`kubernetes/apps/argo-system/values.yaml`](kubernetes/apps/argo-system/values.yaml), sync, then `argocd admin initial-password -n argo-system` (or the initial admin secret).
+- Grafana: set `auth.disable_login_form: false` and `auth.basic.enabled: true` in kube-prometheus-stack values, sync, use the chart admin secret.
+
+### Shared PostgreSQL (CloudNativePG)
+
+home-ops runs one CNPG cluster `postgres` in namespace `database` (Longhorn PVC, single instance). Apps get their own role + database:
+
+| App | Role / DB | Connect |
+|-----|-----------|---------|
+| Authentik | `authentik` | `postgres-rw.database.svc.cluster.local:5432` |
+
+**Add another app DB** (e.g. Home Assistant recorder): add `DatabaseRole` + `Database` under [`kubernetes/apps/database/`](kubernetes/apps/database/), password via ExternalSecret (`kubernetes.io/basic-auth` with `cnpg.io/reload: "true"`), point the app at `postgres-rw.database.svc.cluster.local`.
+
 ### Cert bootstrap order
 
 1. External Secrets (`sync-wave: -2`) + `1password-token`
 2. cert-manager chart (`-1`)
 3. Cloudflare ExternalSecret then ClusterIssuer (`cert-manager-config` wave `0`, issuer resource wave `1`)
 4. Gateway Certificate → HTTPS routes
+5. CloudNativePG operator (`0`) → shared `postgres` cluster (`1`) → Authentik (`2`) then app OIDC / proxy routes
 
 ## SecureBoot / TPM
 
@@ -126,10 +160,10 @@ home-ops runs a light metrics + logs + Hubble stack (home-ops only, under `argo/
 
 | UI | URL |
 |----|-----|
-| Grafana | https://grafana.home-ops.nl |
-| Hubble UI | https://hubble.home-ops.nl |
+| Grafana | https://grafana.home-ops.nl (Authentik OIDC) |
+| Hubble UI | https://hubble.home-ops.nl (Authentik proxy) |
 
-Grafana admin password: `kubectl -n monitoring get secret kube-prometheus-stack-grafana -o jsonpath='{.data.admin-password}' | base64 -d`.
+Grafana uses Authentik SSO (local login disabled). See [Authentication (default deny)](#authentication-default-deny) for break-glass.
 
 To scrape a new app, add a `ServiceMonitor`/`PodMonitor` in the app namespace (or under [`kubernetes/apps/monitoring/`](kubernetes/apps/monitoring/)); Prometheus is configured with empty selectors so it picks up cluster-wide monitors. Spegel ServiceMonitor is enabled in chart values (needs Prometheus Operator CRDs — Spegel Application uses `SkipDryRunOnMissingResource`).
 

--- a/kubernetes/apps/argo-system/externalsecret-oidc.yaml
+++ b/kubernetes/apps/argo-system/externalsecret-oidc.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-oidc
+  namespace: argo-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: argocd-secret
+    creationPolicy: Merge
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      data:
+        oidc.authentik.clientSecret: "{{ .ARGOCD_CLIENT_SECRET }}"
+  dataFrom:
+    - extract:
+        key: authentik

--- a/kubernetes/apps/argo-system/kustomization.yaml
+++ b/kubernetes/apps/argo-system/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ./httproute.yaml
   - ./networkpolicy.yaml
+  - ./externalsecret-oidc.yaml

--- a/kubernetes/apps/argo-system/values.yaml
+++ b/kubernetes/apps/argo-system/values.yaml
@@ -3,3 +3,26 @@ configs:
   params:
     server.insecure: true
     controller.diff.server.side: true
+  cm:
+    url: https://argocd.home-ops.nl
+    # Local admin disabled; use Authentik OIDC. Break-glass: set to "true" and sync.
+    admin.enabled: "false"
+    oidc.config: |
+      name: Authentik
+      issuer: https://authentik.home-ops.nl/application/o/argocd/
+      clientID: argocd
+      clientSecret: $oidc.authentik.clientSecret
+      requestedScopes:
+        - openid
+        - profile
+        - email
+        - offline_access
+      requestedIDTokenClaims:
+        groups:
+          essential: true
+  rbac:
+    policy.default: ""
+    policy.csv: |
+      g, ArgoCD Admins, role:admin
+      g, Home Ops Users, role:readonly
+    scopes: '[groups]'

--- a/kubernetes/apps/authentik/blueprints.yaml
+++ b/kubernetes/apps/authentik/blueprints.yaml
@@ -1,0 +1,182 @@
+---
+# GitOps blueprints: OIDC for Argo/Grafana + proxy for Hubble/Longhorn.
+# Client secrets come from env (authentik-oidc-clients) via !Env.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprints
+  namespace: authentik
+data:
+  home-ops-apps.yaml: |
+    # yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+    version: 1
+    metadata:
+      name: home-ops-apps
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: ArgoCD Admins
+        attrs:
+          name: ArgoCD Admins
+          users:
+            - !Find [authentik_core.user, [username, akadmin]]
+
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: Grafana Admins
+        attrs:
+          name: Grafana Admins
+          users:
+            - !Find [authentik_core.user, [username, akadmin]]
+
+      - model: authentik_core.group
+        state: present
+        identifiers:
+          name: Home Ops Users
+        attrs:
+          name: Home Ops Users
+          users:
+            - !Find [authentik_core.user, [username, akadmin]]
+
+      - model: authentik_providers_oauth2.oauth2provider
+        state: present
+        identifiers:
+          name: Provider for Argo CD
+        attrs:
+          name: Provider for Argo CD
+          client_type: confidential
+          client_id: argocd
+          client_secret: !Env ARGOCD_CLIENT_SECRET
+          redirect_uris:
+            - matching_mode: strict
+              url: https://argocd.home-ops.nl/auth/callback
+          include_claims_in_id_token: true
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, offline_access]]
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: argocd
+        attrs:
+          name: Argo CD
+          slug: argocd
+          group: Home Ops
+          meta_launch_url: https://argocd.home-ops.nl
+          open_in_new_tab: true
+          policy_engine_mode: any
+          provider: !Find [authentik_providers_oauth2.oauth2provider, [name, Provider for Argo CD]]
+
+      - model: authentik_providers_oauth2.oauth2provider
+        state: present
+        identifiers:
+          name: Provider for Grafana
+        attrs:
+          name: Provider for Grafana
+          client_type: confidential
+          client_id: grafana
+          client_secret: !Env GRAFANA_CLIENT_SECRET
+          redirect_uris:
+            - matching_mode: strict
+              url: https://grafana.home-ops.nl/login/generic_oauth
+          include_claims_in_id_token: true
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, offline_access]]
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: grafana
+        attrs:
+          name: Grafana
+          slug: grafana
+          group: Home Ops
+          meta_launch_url: https://grafana.home-ops.nl
+          open_in_new_tab: true
+          policy_engine_mode: any
+          provider: !Find [authentik_providers_oauth2.oauth2provider, [name, Provider for Grafana]]
+
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: Provider for Hubble
+        attrs:
+          name: Provider for Hubble
+          mode: proxy
+          external_host: https://hubble.home-ops.nl
+          internal_host: http://hubble-ui.kube-system.svc.cluster.local:80
+          internal_host_ssl_validation: false
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          access_token_validity: hours=24
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: hubble
+        attrs:
+          name: Hubble UI
+          slug: hubble
+          group: Home Ops
+          meta_launch_url: https://hubble.home-ops.nl
+          open_in_new_tab: true
+          policy_engine_mode: any
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Hubble]]
+
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: Provider for Longhorn
+        attrs:
+          name: Provider for Longhorn
+          mode: proxy
+          external_host: https://longhorn.home-ops.nl
+          internal_host: http://longhorn-frontend.longhorn-system.svc.cluster.local:80
+          internal_host_ssl_validation: false
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          access_token_validity: hours=24
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: longhorn
+        attrs:
+          name: Longhorn
+          slug: longhorn
+          group: Home Ops
+          meta_launch_url: https://longhorn.home-ops.nl
+          open_in_new_tab: true
+          policy_engine_mode: any
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Longhorn]]
+
+      # Attach proxy apps to the embedded outpost (served on authentik-server:80 → :9000).
+      - model: authentik_outposts.outpost
+        state: present
+        identifiers:
+          name: authentik Embedded Outpost
+        attrs:
+          name: authentik Embedded Outpost
+          providers:
+            - !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Hubble]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Longhorn]]

--- a/kubernetes/apps/authentik/externalsecret.yaml
+++ b/kubernetes/apps/authentik/externalsecret.yaml
@@ -1,0 +1,61 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# 1Password item "authentik" in vault k8s-secrets must contain:
+#   SECRET_KEY, POSTGRES_PASSWORD, BOOTSTRAP_PASSWORD, BOOTSTRAP_EMAIL
+#   ARGOCD_CLIENT_SECRET, GRAFANA_CLIENT_SECRET
+# POSTGRES_PASSWORD is the Authentik role password on the shared CNPG cluster
+# (also synced to database/authentik-db for DatabaseRole).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-app
+  namespace: authentik
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: authentik-app
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        AUTHENTIK_SECRET_KEY: "{{ .SECRET_KEY }}"
+        AUTHENTIK_POSTGRESQL__HOST: postgres-rw.database.svc.cluster.local
+        AUTHENTIK_POSTGRESQL__PORT: "5432"
+        AUTHENTIK_POSTGRESQL__NAME: authentik
+        AUTHENTIK_POSTGRESQL__USER: authentik
+        AUTHENTIK_POSTGRESQL__PASSWORD: "{{ .POSTGRES_PASSWORD }}"
+        AUTHENTIK_BOOTSTRAP_PASSWORD: "{{ .BOOTSTRAP_PASSWORD }}"
+        AUTHENTIK_BOOTSTRAP_EMAIL: "{{ .BOOTSTRAP_EMAIL }}"
+  dataFrom:
+    - extract:
+        key: authentik
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-oidc-clients
+  namespace: authentik
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: authentik-oidc-clients
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        ARGOCD_CLIENT_SECRET: "{{ .ARGOCD_CLIENT_SECRET }}"
+        GRAFANA_CLIENT_SECRET: "{{ .GRAFANA_CLIENT_SECRET }}"
+  dataFrom:
+    - extract:
+        key: authentik

--- a/kubernetes/apps/authentik/httproute.yaml
+++ b/kubernetes/apps/authentik/httproute.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: authentik
+  namespace: authentik
+spec:
+  hostnames:
+    - authentik.home-ops.nl
+  parentRefs:
+    - name: external
+      namespace: kube-system
+  rules:
+    - backendRefs:
+        - name: authentik-server
+          port: 80
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+---
+# Cross-namespace backends: Hubble/Longhorn HTTPRoutes → authentik-server (embedded proxy outpost).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-proxy-httproutes
+  namespace: authentik
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: kube-system
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: longhorn-system
+  to:
+    - group: ""
+      kind: Service
+      name: authentik-server

--- a/kubernetes/apps/authentik/kustomization.yaml
+++ b/kubernetes/apps/authentik/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: authentik
+resources:
+  - externalsecret.yaml
+  - blueprints.yaml
+  - httproute.yaml

--- a/kubernetes/apps/authentik/values.yaml
+++ b/kubernetes/apps/authentik/values.yaml
@@ -1,0 +1,54 @@
+# Home-ops sized Authentik: single replicas.
+# Postgres: shared CloudNativePG cluster (postgres-rw.database.svc).
+# Secrets: ExternalSecret authentik-app (1Password item "authentik").
+
+authentik:
+  enabled: true
+  log_level: info
+  existingSecret:
+    secretName: authentik-app
+  error_reporting:
+    enabled: false
+
+blueprints:
+  configMaps:
+    - authentik-blueprints
+
+global:
+  envFrom:
+    - secretRef:
+        name: authentik-oidc-clients
+
+server:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 1024Mi
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+  route:
+    main:
+      enabled: false
+  ingress:
+    enabled: false
+
+worker:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      memory: 768Mi
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+
+postgresql:
+  enabled: false

--- a/kubernetes/apps/cnpg/values.yaml
+++ b/kubernetes/apps/cnpg/values.yaml
@@ -1,0 +1,20 @@
+# CloudNativePG operator — cluster-wide, single replica (home-ops sized).
+replicaCount: 1
+
+crds:
+  create: true
+
+config:
+  clusterWide: true
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    memory: 256Mi
+
+monitoring:
+  podMonitorEnabled: true
+  grafanaDashboard:
+    create: false

--- a/kubernetes/apps/database/authentik-db.yaml
+++ b/kubernetes/apps/database/authentik-db.yaml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Password from 1Password item "authentik" field POSTGRES_PASSWORD.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: authentik-db
+  namespace: database
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: authentik-db
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: kubernetes.io/basic-auth
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        username: authentik
+        password: "{{ .POSTGRES_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: authentik
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: DatabaseRole
+metadata:
+  name: authentik
+  namespace: database
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  cluster:
+    name: postgres
+  name: authentik
+  login: true
+  passwordSecret:
+    name: authentik-db
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: authentik
+  namespace: database
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  cluster:
+    name: postgres
+  name: authentik
+  owner: authentik
+  databaseReclaimPolicy: retain

--- a/kubernetes/apps/database/cluster.yaml
+++ b/kubernetes/apps/database/cluster.yaml
@@ -1,0 +1,26 @@
+---
+# Shared Postgres for Authentik, Home Assistant recorder, and future apps.
+# Add per-app DatabaseRole + Database manifests alongside this cluster.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: database
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  instances: 1
+  storage:
+    size: 20Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 1536Mi
+  monitoring:
+    enablePodMonitor: true
+  bootstrap:
+    initdb:
+      database: app
+      owner: app

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: database
+resources:
+  - cluster.yaml
+  - authentik-db.yaml

--- a/kubernetes/apps/kube-system/cilium/gateway-api/httproute-hubble.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway-api/httproute-hubble.yaml
@@ -11,8 +11,10 @@ spec:
     - name: external
       namespace: kube-system
   rules:
+    # Embedded Authentik proxy outpost (Host-based) → Hubble UI upstream.
     - backendRefs:
-        - name: hubble-ui
+        - name: authentik-server
+          namespace: authentik
           port: 80
       matches:
         - path:

--- a/kubernetes/apps/longhorn-system/httproute.yaml
+++ b/kubernetes/apps/longhorn-system/httproute.yaml
@@ -11,8 +11,10 @@ spec:
   - name: external
     namespace: kube-system
   rules:
+  # Embedded Authentik proxy outpost (Host-based) → Longhorn UI upstream.
   - backendRefs:
-    - name: longhorn-frontend
+    - name: authentik-server
+      namespace: authentik
       port: 80
     matches:
     - path:

--- a/kubernetes/apps/monitoring/externalsecret-grafana-oidc.yaml
+++ b/kubernetes/apps/monitoring/externalsecret-grafana-oidc.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-oidc
+  namespace: monitoring
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password
+  target:
+    name: grafana-oidc
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        client_secret: "{{ .GRAFANA_CLIENT_SECRET }}"
+  dataFrom:
+    - extract:
+        key: authentik

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/values.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/values.yaml
@@ -29,11 +29,37 @@ grafana:
   replicas: 1
   admin:
     existingSecret: ""
-  # Password is stored in Secret grafana-admin (chart-generated) until rotated via 1Password.
+  # OIDC via Authentik; client secret from ExternalSecret grafana-oidc.
+  # Local login form/basic auth disabled (break-glass: re-enable in values and sync).
+  envValueFrom:
+    GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET:
+      secretKeyRef:
+        name: grafana-oidc
+        key: client_secret
   grafana.ini:
     server:
       root_url: https://grafana.home-ops.nl
       domain: grafana.home-ops.nl
+    auth:
+      disable_login_form: true
+    auth.basic:
+      enabled: false
+    auth.generic_oauth:
+      enabled: true
+      name: Authentik
+      allow_sign_up: true
+      auto_login: false
+      client_id: grafana
+      scopes: openid profile email offline_access
+      auth_url: https://authentik.home-ops.nl/application/o/authorize/
+      token_url: https://authentik.home-ops.nl/application/o/token/
+      api_url: https://authentik.home-ops.nl/application/o/userinfo/
+      role_attribute_path: contains(groups[*], 'Grafana Admins') && 'Admin' || contains(groups[*], 'Home Ops Users') && 'Editor' || 'Viewer'
+      login_attribute_path: preferred_username
+      name_attribute_path: name
+      email_attribute_path: email
+      groups_attribute_path: groups
+      use_pkce: true
   ingress:
     enabled: false
   serviceMonitor:

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - httproute-grafana.yaml
   - grafana-datasource-loki.yaml
+  - externalsecret-grafana-oidc.yaml

--- a/kubernetes/argo/clusters/home-ops/authentik.yaml
+++ b/kubernetes/argo/clusters/home-ops/authentik.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: authentik
+  namespace: argo-system
+  annotations:
+    # After shared CNPG cluster + authentik Database/Role (postgres wave 1).
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: default
+  destination:
+    name: in-cluster
+    namespace: authentik
+  sources:
+    - repoURL: https://charts.goauthentik.io
+      chart: authentik
+      targetRevision: 2026.5.6
+      helm:
+        releaseName: authentik
+        valueFiles:
+          - $repo/kubernetes/apps/authentik/values.yaml
+    - repoURL: "https://github.com/wouterbouvy/home-ops.git"
+      path: kubernetes/apps/authentik
+      targetRevision: main
+      ref: repo
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+      - ServerSideApply=true
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+      - SkipDryRunOnMissingResource=true
+  ignoreDifferences:
+    - group: ""
+      kind: Secret
+      name: authentik-app
+      jsonPointers:
+        - /data
+    - group: ""
+      kind: Secret
+      name: authentik-oidc-clients
+      jsonPointers:
+        - /data

--- a/kubernetes/argo/clusters/home-ops/cloudnative-pg.yaml
+++ b/kubernetes/argo/clusters/home-ops/cloudnative-pg.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cloudnative-pg
+  namespace: argo-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: default
+  destination:
+    name: in-cluster
+    namespace: cnpg-system
+  sources:
+    - repoURL: https://cloudnative-pg.github.io/charts
+      chart: cloudnative-pg
+      targetRevision: 0.29.0
+      helm:
+        releaseName: cnpg
+        valueFiles:
+          - $repo/kubernetes/apps/cnpg/values.yaml
+    - repoURL: "https://github.com/wouterbouvy/home-ops.git"
+      targetRevision: main
+      ref: repo
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+      - ServerSideApply=true
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+      - SkipDryRunOnMissingResource=true

--- a/kubernetes/argo/clusters/home-ops/kustomization.yaml
+++ b/kubernetes/argo/clusters/home-ops/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 resources:
   - ../../common
   - longhorn.yaml
+  - cloudnative-pg.yaml
+  - postgres.yaml
+  - authentik.yaml
   - metrics-server.yaml
   - kube-prometheus-stack.yaml
   - loki.yaml

--- a/kubernetes/argo/clusters/home-ops/postgres.yaml
+++ b/kubernetes/argo/clusters/home-ops/postgres.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postgres
+  namespace: argo-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  destination:
+    name: in-cluster
+    namespace: database
+  source:
+    repoURL: "https://github.com/wouterbouvy/home-ops.git"
+    path: kubernetes/apps/database
+    targetRevision: main
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+      - ServerSideApply=true
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+      - SkipDryRunOnMissingResource=true
+  ignoreDifferences:
+    - group: ""
+      kind: Secret
+      name: authentik-db
+      jsonPointers:
+        - /data


### PR DESCRIPTION
## Summary
- Deploy Authentik as in-cluster IdP with blueprints for Argo/Grafana OIDC and Hubble/Longhorn proxy providers.
- Add CloudNativePG operator + shared `postgres` cluster; Authentik uses an external DB role/database (no bundled Postgres).
- Disable local Argo/Grafana admin login; document default-deny public auth, 1Password fields, and break-glass recovery.

## Test plan
- [ ] Confirm 1Password item `authentik` exists in `k8s-secrets` (already created)
- [ ] Merge and wait for Argo: `cloudnative-pg` → `postgres` → `authentik` Healthy
- [ ] Log in at `https://authentik.home-ops.nl` as `akadmin`; confirm groups
- [ ] Verify Argo CD and Grafana OIDC login
- [ ] Verify Hubble/Longhorn redirect through Authentik proxy
- [ ] Confirm no unprotected public HTTPRoutes remain (except Authentik itself)


Made with [Cursor](https://cursor.com)