### PR TITLE
Cut over to Let's Encrypt production TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,10 @@ Full mgmt bootstrap and testing still need Omni machine wiring later. When ready
 | Internal Gateway VIP | `10.0.8.110` |
 | Example hosts | `authentik.home-ops.nl`, `argocd.home-ops.nl`, `longhorn.home-ops.nl`, `grafana.home-ops.nl`, `hubble.home-ops.nl` |
 
-**TLS uses Let's Encrypt staging on purpose** while the lab is under active change:
+**TLS:** Let's Encrypt **production** via DNS-01 (Cloudflare):
 
-- ClusterIssuer: `letsencrypt-staging`
-- Certificate / secret: `home-ops-nl-staging` → `home-ops-nl-staging-tls`
-- Browsers will show a trust warning (staging CA). That is expected.
-- Production issuer stays commented until a deliberate cutover.
+- ClusterIssuer: `letsencrypt-production`
+- Certificate / secret: `home-ops-nl` → `home-ops-nl-tls` (covers `home-ops.nl` and `*.home-ops.nl`)
 
 Point Cloudflare DNS for `*.home-ops.nl` at `10.0.8.120`.
 
@@ -168,6 +166,4 @@ Grafana uses Authentik SSO (local login disabled). See [Authentication (default 
 To scrape a new app, add a `ServiceMonitor`/`PodMonitor` in the app namespace (or under [`kubernetes/apps/monitoring/`](kubernetes/apps/monitoring/)); Prometheus is configured with empty selectors so it picks up cluster-wide monitors. Spegel ServiceMonitor is enabled in chart values (needs Prometheus Operator CRDs — Spegel Application uses `SkipDryRunOnMissingResource`).
 
 Talos etcd / controller-manager / scheduler / kube-proxy scrapes are **disabled** in kube-prometheus-stack values (not reachable like kubeadm).
-
-**Production TLS** for `home-ops.nl` remains deferred (staging LE on purpose; see Ingress and TLS above).
 

--- a/kubernetes/apps/cert-manager/clusterissuer.yaml
+++ b/kubernetes/apps/cert-manager/clusterissuer.yaml
@@ -1,20 +1,18 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cert-manager.io/clusterissuer_v1.json
-# Intentional: Let's Encrypt staging for home-ops.nl while the lab is under active
-# change (browsers warn; avoids HSTS friction). Production issuer stays commented
-# until a deliberate cutover — see root README.
+# Production Let's Encrypt for home-ops.nl (needed for trusted OIDC / browser TLS).
+# Staging issuer kept commented for emergency rollback.
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: letsencrypt-staging
+  name: letsencrypt-production
   annotations:
     argocd.argoproj.io/sync-wave: '1'
 spec:
   acme:
-    server: https://acme-staging-v02.api.letsencrypt.org/directory # For staging
-    # server: https://acme-v02.api.letsencrypt.org/directory # For production
+    server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
-      name: letsencrypt-staging
+      name: letsencrypt-production
     solvers:
       - dns01:
           cloudflare:
@@ -27,15 +25,14 @@ spec:
 # apiVersion: cert-manager.io/v1
 # kind: ClusterIssuer
 # metadata:
-#   name: letsencrypt-production
+#   name: letsencrypt-staging
 #   annotations:
 #     argocd.argoproj.io/sync-wave: '1'
 # spec:
 #   acme:
-#     # server: https://acme-staging-v02.api.letsencrypt.org/directory # For staging
-#     server: https://acme-v02.api.letsencrypt.org/directory # For production
+#     server: https://acme-staging-v02.api.letsencrypt.org/directory
 #     privateKeySecretRef:
-#       name: letsencrypt-production
+#       name: letsencrypt-staging
 #     solvers:
 #       - dns01:
 #           cloudflare:

--- a/kubernetes/apps/kube-system/cilium/gateway-api/certificate.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway-api/certificate.yaml
@@ -1,12 +1,11 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: home-ops-nl-staging
-  # Staging LE cert (intentional). See root README TLS section.
+  name: home-ops-nl
 spec:
-  secretName: home-ops-nl-staging-tls
+  secretName: home-ops-nl-tls
   issuerRef:
-    name: letsencrypt-staging
+    name: letsencrypt-production
     kind: ClusterIssuer
   commonName: home-ops.nl
   dnsNames:

--- a/kubernetes/apps/kube-system/cilium/gateway-api/external-gateway.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway-api/external-gateway.yaml
@@ -30,4 +30,4 @@ spec:
       tls:
         certificateRefs:
           - kind: Secret
-            name: home-ops-nl-staging-tls
+            name: home-ops-nl-tls

--- a/kubernetes/apps/kube-system/cilium/gateway-api/internal-gateway.yaml
+++ b/kubernetes/apps/kube-system/cilium/gateway-api/internal-gateway.yaml
@@ -30,4 +30,4 @@ spec:
       tls:
         certificateRefs:
           - kind: Secret
-            name: home-ops-nl-staging-tls
+            name: home-ops-nl-tls


### PR DESCRIPTION
## Summary
- Enable `letsencrypt-production` ClusterIssuer; keep staging commented for rollback.
- Reissue Gateway Certificate as `home-ops-nl` → secret `home-ops-nl-tls` and point external/internal Gateways at it.
- Update README (staging LE / deferred production notes removed).

## Test plan
- [ ] Merge and wait for cert-manager Certificate `home-ops-nl` Ready
- [ ] Confirm Gateways reference `home-ops-nl-tls` and HTTPS works without browser trust warning
- [ ] Retry Argo CD / Grafana OIDC login against Authentik
- [ ] Optional: delete leftover `home-ops-nl-staging` / `home-ops-nl-staging-tls` if still present after prune


Made with [Cursor](https://cursor.com)