### PR TITLE
Fix Authentik OAuth grant_types for OIDC login

### DIFF
--- a/kubernetes/apps/authentik/blueprints.yaml
+++ b/kubernetes/apps/authentik/blueprints.yaml
@@ -51,6 +51,10 @@ data:
           client_type: confidential
           client_id: argocd
           client_secret: !Env ARGOCD_CLIENT_SECRET
+          # Authentik 2026.5+: empty grant_types rejects all authorize requests.
+          grant_types:
+            - authorization_code
+            - refresh_token
           redirect_uris:
             - matching_mode: strict
               url: https://argocd.home-ops.nl/auth/callback
@@ -87,6 +91,10 @@ data:
           client_type: confidential
           client_id: grafana
           client_secret: !Env GRAFANA_CLIENT_SECRET
+          # Authentik 2026.5+: empty grant_types rejects all authorize requests.
+          grant_types:
+            - authorization_code
+            - refresh_token
           redirect_uris:
             - matching_mode: strict
               url: https://grafana.home-ops.nl/login/generic_oauth

--- a/kubernetes/apps/authentik/blueprints.yaml
+++ b/kubernetes/apps/authentik/blueprints.yaml
@@ -185,6 +185,9 @@ data:
           name: authentik Embedded Outpost
         attrs:
           name: authentik Embedded Outpost
+          # Empty authentik_host makes proxy start redirects use http://localhost/...
+          config:
+            authentik_host: https://authentik.home-ops.nl
           providers:
             - !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Hubble]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Longhorn]]


### PR DESCRIPTION
## Summary
- Authentik 2026.5+ rejects `/application/o/authorize/` when OAuth2 providers have empty `grant_types` (`invalid_request` / “The request is otherwise malformed”).
- Blueprint-created Argo CD and Grafana providers had `grant_types=[]`; add `authorization_code` and `refresh_token`.
- Pin embedded outpost `authentik_host` to `https://authentik.home-ops.nl` so Hubble/Longhorn proxy start redirects do not use `http://localhost`.
- Live cluster was hotfixed the same way so SSO testing could continue before merge.

## Test plan
- [x] Live hotfix: Grafana authorize returns 302 to `default-authentication-flow` (not `invalid_request`)
- [x] OIDC discovery for Argo/Grafana returns 200 over prod TLS
- [x] Grafana `/login/generic_oauth` → Authentik authorize → login flow
- [x] Browser: Argo CD OIDC authorize + token exchange succeeded (akadmin)
- [x] Browser: Grafana OIDC authorize + token exchange succeeded (akadmin)
- [x] Hubble/Longhorn outpost start → `https://authentik.home-ops.nl/application/o/authorize/...` (not localhost)
- [ ] After merge: confirm blueprint re-apply keeps grant_types + authentik_host