### PR TITLE
Load Omni 1Password credentials only for omnictl tasks

### DIFF
--- a/.cursor/rules/omni-service-account.mdc
+++ b/.cursor/rules/omni-service-account.mdc
@@ -7,7 +7,7 @@ alwaysApply: true
 
 Use the Omni **Cursor** service account for all `omnictl` / Omni API work. Do not trigger personal browser/SideroV1 login.
 
-- mise loads credentials via [`scripts/omni-sa-env.sh`](scripts/omni-sa-env.sh) from 1Password (`op://k8s-secrets/dfmszcq3udnskcc4cvrzrr4hai`).
-- Prefer `mise exec -- omnictl …` or `mise run omni-*` so env is applied.
+- Credentials load lazily via [`scripts/with-omni-sa.sh`](scripts/with-omni-sa.sh) → [`scripts/omni-sa-env.sh`](scripts/omni-sa-env.sh) from 1Password (`op://k8s-secrets/dfmszcq3udnskcc4cvrzrr4hai`). They are **not** in global mise `[env]`.
+- Prefer `mise run omni-*` or `mise run omnictl -- …` so 1Password auth runs only for Omni actions.
 - Never set `OMNICONFIG` in the same shell as `OMNI_ENDPOINT` / `OMNI_SERVICE_ACCOUNT_KEY`.
 - Do not print `OMNI_SERVICE_ACCOUNT_KEY` or commit it.

--- a/.cursor/rules/plans-in-workspace.mdc
+++ b/.cursor/rules/plans-in-workspace.mdc
@@ -1,0 +1,28 @@
+---
+description: Store plans in workspace .cursor/plans/; never put secrets in plans
+alwaysApply: true
+---
+
+# Plans live in the workspace
+
+When creating or updating plans (CreatePlan, plan mode, or any `*.plan.md` file):
+
+- **Always** write the plan under the workspace: `.cursor/plans/<name>.plan.md`
+- Do **not** leave the only copy under `~/.cursor/plans/` — if a plan is created there, copy or write it into the workspace path as well
+- Plans are gitignored (see `.gitignore`); keep them local to this repo for context across chats
+
+Example path:
+
+```text
+.cursor/plans/kubevirt_multus_vms_1678f99c.plan.md
+```
+
+# Never store secrets in plans
+
+Plans must not contain secrets or credentials, even though they are gitignored.
+
+**Do not include:** passwords, API keys, tokens, private keys, kubeconfigs, OAuth client secrets, 1Password item contents, `op read` output, Connection strings with credentials, or pasted Secret/YAML data values.
+
+**OK to include:** secret *names*, ExternalSecret/1Password *item references* (e.g. `op://Vault/Item/field`), file paths, and “create in 1Password / wire via ESO” steps — never the secret values themselves.
+
+If a secret appears in a plan by mistake, remove it immediately and rotate if it was a real credential.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Trash
 .DS_Store
 Thumbs.db
+# Cursor agent plans (local only)
+.cursor/plans/
 # k8s / Omni local credentials
 kubeconfig
 talosconfig

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,13 +1,11 @@
 redactions = ["OMNI_SERVICE_ACCOUNT_KEY"]
 
 [env]
-# Omni: Cursor service account via 1Password (scripts/omni-sa-env.sh). Do not set
-# OMNICONFIG alongside OMNI_ENDPOINT / OMNI_SERVICE_ACCOUNT_KEY — they conflict.
-OMNICONFIG = false
+# Omni SA is loaded only by scripts/with-omni-sa.sh for omnictl tasks (not every mise run).
+# Do not set OMNICONFIG alongside OMNI_ENDPOINT / OMNI_SERVICE_ACCOUNT_KEY — they conflict.
 KUBECONFIG = "{{config_root}}/kubeconfig"
 TALOSCONFIG = "{{config_root}}/talosconfig"
 _.file = "{{config_root}}/kubernetes/versions.env"
-_.source = { path = "{{config_root}}/scripts/omni-sa-env.sh", tools = true }
 
 [vars]
 cluster = 'default'
@@ -44,10 +42,18 @@ run = [
 ]
 dir = "kubernetes/bootstrap/talos"
 
+[tasks.omnictl]
+description = "Run omnictl with Cursor Omni SA from 1Password"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+exec "{{config_root}}/scripts/with-omni-sa.sh" omnictl "$@"
+"""
+
 [tasks.omni-validate]
 description = "Validate home-ops Omni cluster template"
 run = [
-    "omnictl cluster template validate -f omni-home-ops.yaml",
+    "{{config_root}}/scripts/with-omni-sa.sh omnictl cluster template validate -f omni-home-ops.yaml",
 ]
 dir = "kubernetes/bootstrap/talos"
 
@@ -55,9 +61,9 @@ dir = "kubernetes/bootstrap/talos"
 description = "Sync home-ops cluster; merge kube/talos contexts and set home-ops as default"
 run = [
     "mise run manifests-render",
-    "omnictl cluster template sync -f omni-home-ops.yaml",
-    "omnictl talosconfig -c home-ops --merge $TALOSCONFIG",
-    "omnictl kubeconfig -c home-ops --merge --force-context-name {{vars.kube_context_home_ops}} $KUBECONFIG",
+    "{{config_root}}/scripts/with-omni-sa.sh omnictl cluster template sync -f omni-home-ops.yaml",
+    "{{config_root}}/scripts/with-omni-sa.sh omnictl talosconfig -c home-ops --merge $TALOSCONFIG",
+    "{{config_root}}/scripts/with-omni-sa.sh omnictl kubeconfig -c home-ops --merge --force-context-name {{vars.kube_context_home_ops}} $KUBECONFIG",
     "kubectl config use-context {{vars.kube_context_home_ops}}",
     # omnictl --merge already selects the new Talos context (named like k5s-home-ops-home-ops)
 ]
@@ -87,13 +93,13 @@ run = [
 
 [tasks.omni-reset]
 description = "Reset home-ops cluster template"
-run = "omnictl cluster template delete -f omni-home-ops.yaml"
+run = "{{config_root}}/scripts/with-omni-sa.sh omnictl cluster template delete -f omni-home-ops.yaml"
 dir = "kubernetes/bootstrap/talos"
 
 [tasks.omni-mgmt-validate]
 description = "Validate management Omni cluster template (scaffold; full testing later)"
 run = [
-    "omnictl cluster template validate -f omni-mgmt.yaml",
+    "{{config_root}}/scripts/with-omni-sa.sh omnictl cluster template validate -f omni-mgmt.yaml",
 ]
 dir = "kubernetes/bootstrap/talos"
 
@@ -101,9 +107,9 @@ dir = "kubernetes/bootstrap/talos"
 description = "Sync management cluster; merge contexts into shared kube/talos configs; keep home-ops default"
 run = [
     "mise run manifests-render",
-    "omnictl cluster template sync -f omni-mgmt.yaml",
-    "omnictl talosconfig -c management --merge $TALOSCONFIG",
-    "omnictl kubeconfig -c management --merge --force-context-name {{vars.kube_context_mgmt}} $KUBECONFIG",
+    "{{config_root}}/scripts/with-omni-sa.sh omnictl cluster template sync -f omni-mgmt.yaml",
+    "{{config_root}}/scripts/with-omni-sa.sh omnictl talosconfig -c management --merge $TALOSCONFIG",
+    "{{config_root}}/scripts/with-omni-sa.sh omnictl kubeconfig -c management --merge --force-context-name {{vars.kube_context_mgmt}} $KUBECONFIG",
     "kubectl config use-context {{vars.kube_context_home_ops}}",
     # Prefer the home-ops Talos context if present (Omni name, not 'home-ops')
     "bash -c 'ctx=$(talosctl config contexts | awk \"NR>1 {n=(\\$1==\\\"*\\\"?\\$2:\\$1); if (n ~ /home-ops/ && n !~ /management/) print n}\" | head -1); [ -n \\\"$ctx\\\" ] && talosctl config context \\\"$ctx\\\"'",
@@ -113,7 +119,7 @@ depends = ["omni-mgmt-validate"]
 
 [tasks.omni-mgmt-reset]
 description = "Reset management cluster template"
-run = "omnictl cluster template delete -f omni-mgmt.yaml"
+run = "{{config_root}}/scripts/with-omni-sa.sh omnictl cluster template delete -f omni-mgmt.yaml"
 dir = "kubernetes/bootstrap/talos"
 
 [tasks.omni-wipedisks]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ flowchart TD
 ## Prerequisites
 
 - [mise](https://mise.jdx.dev/) (`mise install` from [`.mise.toml`](.mise.toml))
-- [1Password CLI](https://developer.1password.com/docs/cli/) signed in (`op`) — mise loads the Omni **Cursor** service account from vault `k8s-secrets` (item `Omni Cursor service account`) and sets `OMNI_ENDPOINT` / `OMNI_SERVICE_ACCOUNT_KEY` (see [`scripts/omni-sa-env.sh`](scripts/omni-sa-env.sh))
+- [1Password CLI](https://developer.1password.com/docs/cli/) signed in (`op`) when running Omni tasks — `mise run omni-*` / `mise run omnictl` load the **Cursor** service account from vault `k8s-secrets` (item `Omni Cursor service account`) via [`scripts/with-omni-sa.sh`](scripts/with-omni-sa.sh) (other mise commands do not prompt)
 - Local-only files (gitignored): `kubeconfig`, `talosconfig`, `HWIDs.md` (`omniconfig` is optional for personal UI/cli outside mise)
 
 ## Bootstrap (home-ops)

--- a/scripts/omni-sa-env.sh
+++ b/scripts/omni-sa-env.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-# Sourced by mise ([env] _.source). Loads the Cursor Omni service account from 1Password.
+# Sourced by scripts/with-omni-sa.sh (mise omni-* / omnictl tasks).
+# Loads the Cursor Omni service account from 1Password.
 # Requires: `op` signed in; item "Omni Cursor service account" in vault k8s-secrets.
 # OMNI_* env vars replace personal omniconfig auth — do not set OMNICONFIG alongside them.
 
 OMNI_SA_OP_REF="${OMNI_SA_OP_REF:-op://k8s-secrets/dfmszcq3udnskcc4cvrzrr4hai}"
 
 if ! command -v op >/dev/null 2>&1; then
-  echo "omni-sa-env: op CLI not found; skipping Omni service account load" >&2
-  return 0 2>/dev/null || exit 0
+  echo "omni-sa-env: op CLI not found; cannot load Omni service account" >&2
+  return 1 2>/dev/null || exit 1
 fi
 
 export OMNI_ENDPOINT

--- a/scripts/with-omni-sa.sh
+++ b/scripts/with-omni-sa.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Load Cursor Omni SA from 1Password, then exec the given command.
+# Used by mise omni-* / omnictl tasks — not sourced on every mise activation.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=omni-sa-env.sh
+source "${SCRIPT_DIR}/omni-sa-env.sh"
+exec "$@"


### PR DESCRIPTION
## Summary
- Remove global mise `[env]` sourcing of the Omni Cursor service account so everyday `mise` / kubectl / helm / render work no longer prompts for 1Password
- Load `OMNI_*` via `scripts/with-omni-sa.sh` only for `omnictl` tasks, plus a `mise run omnictl -- …` passthrough
- Update README and the Omni agent rule for the lazy auth flow

## Test plan
- [ ] `mise env` shows no `OMNI_ENDPOINT` / `OMNI_SERVICE_ACCOUNT_KEY`
- [ ] `mise run manifests-render` runs without a 1Password prompt
- [ ] `mise run omni-validate` prompts once and validates the home-ops template
- [ ] `mise run omnictl -- cluster list` works with SA auth


Made with [Cursor](https://cursor.com)