### PR TITLE
Restore post-merge and plan-archive agent rules

### DIFF
--- a/.cursor/rules/git-feature-branches.mdc
+++ b/.cursor/rules/git-feature-branches.mdc
@@ -10,3 +10,12 @@ Always create a **new branch** for new features or non-trivial changes. Do not c
 - Branch from up-to-date `main` (or the user-specified base).
 - Prefer a descriptive prefix such as `cursor/` or `chore/` / `feat/` matching existing repo style.
 - One concern per branch/PR when practical; do not pile unrelated work onto an existing feature branch unless the user asks.
+
+# After merge
+
+Once the PR is **merged**:
+
+1. Check out `main` and pull the latest (`git checkout main && git pull`).
+2. Delete the local feature branch (`git branch -d <branch>`).
+3. Delete the remote feature branch if it still exists (`git push origin --delete <branch>`), unless GitHub already removed it on merge.
+4. Do not keep working on a merged branch; start a new branch from `main` for the next change.

--- a/.cursor/rules/plans-in-workspace.mdc
+++ b/.cursor/rules/plans-in-workspace.mdc
@@ -9,12 +9,14 @@ When creating or updating plans (CreatePlan, plan mode, or any `*.plan.md` file)
 
 - **Always** write the plan under the workspace: `.cursor/plans/<name>.plan.md`
 - Do **not** leave the only copy under `~/.cursor/plans/` — if a plan is created there, copy or write it into the workspace path as well
+- When a plan is **done** (implemented / merged), move it to `.cursor/plans/archive/`
 - Plans are gitignored (see `.gitignore`); keep them local to this repo for context across chats
 
-Example path:
+Example paths:
 
 ```text
 .cursor/plans/kubevirt_multus_vms_1678f99c.plan.md
+.cursor/plans/archive/lazy_omni_1password_afd7c8f7.plan.md
 ```
 
 # Never store secrets in plans


### PR DESCRIPTION
## Summary
- Document post-merge cleanup: return to `main` and delete the feature branch
- Archive completed Cursor plans under `.cursor/plans/archive/`

## Test plan
- [x] Rules match the intended agent workflow


Made with [Cursor](https://cursor.com)