### PR TITLE
Add TODO.md with OSS Loki migration follow-up

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+# TODO
+
+Open follow-ups for home-ops. Check items off when done; remove or archive as needed.
+
+## Observability
+
+- [ ] Migrate Loki from the Grafana (GEL-positioned) Helm chart to the OSS [grafana-community](https://github.com/grafana-community/helm-charts) chart (`repoURL` + any values cleanup; see [upgrade guide](https://grafana.com/docs/loki/latest/setup/upgrade/upgrade-to-community/))


### PR DESCRIPTION
## Summary
- Add a root `TODO.md` for open follow-ups
- Track migrating Loki to the grafana-community (OSS) Helm chart

## Test plan
- [x] `TODO.md` is readable and lists the Loki migration item


Made with [Cursor](https://cursor.com)