### PR TITLE
Default to ready PRs; only draft when asked

### DIFF
--- a/.cursor/rules/git-feature-branches.mdc
+++ b/.cursor/rules/git-feature-branches.mdc
@@ -10,6 +10,7 @@ Always create a **new branch** for new features or non-trivial changes. Do not c
 - Branch from up-to-date `main` (or the user-specified base).
 - Prefer a descriptive prefix such as `cursor/` or `chore/` / `feat/` matching existing repo style.
 - One concern per branch/PR when practical; do not pile unrelated work onto an existing feature branch unless the user asks.
+- **Never** open a **draft** PR unless the user explicitly asks for a draft. Default to a normal (ready) PR.
 
 # After merge
 


### PR DESCRIPTION
## Summary
- Update the git branching agent rule: never open draft PRs unless explicitly requested

## Test plan
- [x] Rule text is clear for agents creating PRs


Made with [Cursor](https://cursor.com)