### PR TITLE
Add Headlamp behind Authentik proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Full mgmt bootstrap and testing still need Omni machine wiring later. When ready
 | Public domain | `home-ops.nl` |
 | External Gateway VIP | `10.0.8.120` |
 | Internal Gateway VIP | `10.0.8.110` |
-| Example hosts | `authentik.home-ops.nl`, `argocd.home-ops.nl`, `longhorn.home-ops.nl`, `grafana.home-ops.nl`, `hubble.home-ops.nl` |
+| Example hosts | `authentik.home-ops.nl`, `argocd.home-ops.nl`, `longhorn.home-ops.nl`, `grafana.home-ops.nl`, `hubble.home-ops.nl`, `headlamp.home-ops.nl` |
 
 **TLS:** Let's Encrypt **production** via DNS-01 (Cloudflare):
 
@@ -109,6 +109,7 @@ Public HTTPS UIs are protected by **Authentik** unless a route is explicitly doc
 | `grafana.home-ops.nl` | Native OIDC → Authentik (login form / basic auth disabled) |
 | `hubble.home-ops.nl` | Authentik **proxy** outpost → Hubble UI |
 | `longhorn.home-ops.nl` | Authentik **proxy** outpost → Longhorn UI |
+| `headlamp.home-ops.nl` | Authentik **proxy** outpost → Headlamp (pod SA → API; shared `cluster-admin`) |
 
 **Add a new public UI:** prefer app-native OIDC against Authentik; if the app has no SSO, put an Authentik proxy provider in [`kubernetes/apps/authentik/blueprints.yaml`](kubernetes/apps/authentik/blueprints.yaml), attach it to the embedded outpost, and point the HTTPRoute at `authentik-server` in `authentik` (see Hubble/Longhorn + ReferenceGrant). Do **not** publish an unprotected HTTPRoute on the external Gateway.
 

--- a/kubernetes/apps/authentik/blueprints.yaml
+++ b/kubernetes/apps/authentik/blueprints.yaml
@@ -178,6 +178,34 @@ data:
           policy_engine_mode: any
           provider: !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Longhorn]]
 
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: Provider for Headlamp
+        attrs:
+          name: Provider for Headlamp
+          mode: proxy
+          external_host: https://headlamp.home-ops.nl
+          internal_host: http://headlamp.headlamp.svc.cluster.local:80
+          internal_host_ssl_validation: false
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          access_token_validity: hours=24
+
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: headlamp
+        attrs:
+          name: Headlamp
+          slug: headlamp
+          group: Home Ops
+          meta_launch_url: https://headlamp.home-ops.nl
+          open_in_new_tab: true
+          policy_engine_mode: any
+          provider: !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Headlamp]]
+
       # Attach proxy apps to the embedded outpost (served on authentik-server:80 → :9000).
       - model: authentik_outposts.outpost
         state: present
@@ -191,3 +219,4 @@ data:
           providers:
             - !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Hubble]]
             - !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Longhorn]]
+            - !Find [authentik_providers_proxy.proxyprovider, [name, Provider for Headlamp]]

--- a/kubernetes/apps/authentik/httproute.yaml
+++ b/kubernetes/apps/authentik/httproute.yaml
@@ -19,7 +19,7 @@ spec:
             type: PathPrefix
             value: /
 ---
-# Cross-namespace backends: Hubble/Longhorn HTTPRoutes → authentik-server (embedded proxy outpost).
+# Cross-namespace backends: proxy HTTPRoutes → authentik-server (embedded outpost).
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
@@ -33,6 +33,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: longhorn-system
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: headlamp
   to:
     - group: ""
       kind: Service

--- a/kubernetes/apps/headlamp/httproute.yaml
+++ b/kubernetes/apps/headlamp/httproute.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: headlamp
+  namespace: headlamp
+spec:
+  hostnames:
+  - headlamp.home-ops.nl
+  parentRefs:
+  - name: external
+    namespace: kube-system
+  rules:
+  # Embedded Authentik proxy outpost (Host-based) → Headlamp upstream.
+  - backendRefs:
+    - name: authentik-server
+      namespace: authentik
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /

--- a/kubernetes/apps/headlamp/kustomization.yaml
+++ b/kubernetes/apps/headlamp/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./httproute.yaml

--- a/kubernetes/apps/headlamp/values.yaml
+++ b/kubernetes/apps/headlamp/values.yaml
@@ -1,0 +1,20 @@
+# Headlamp behind Authentik proxy: SA token for kube-apiserver (shared cluster-admin).
+config:
+  inCluster: true
+  unsafeUseServiceAccountToken: true
+
+ingress:
+  enabled: false
+
+service:
+  type: ClusterIP
+  port: 80
+
+automountServiceAccountToken: true
+
+serviceAccount:
+  create: true
+
+clusterRoleBinding:
+  create: true
+  clusterRoleName: cluster-admin

--- a/kubernetes/argo/clusters/home-ops/headlamp.yaml
+++ b/kubernetes/argo/clusters/home-ops/headlamp.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: headlamp
+  namespace: argo-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  project: default
+  destination:
+    name: in-cluster
+    namespace: headlamp
+  sources:
+    - repoURL: https://kubernetes-sigs.github.io/headlamp/
+      chart: headlamp
+      targetRevision: 0.44.0
+      helm:
+        releaseName: headlamp
+        valueFiles:
+          - $repo/kubernetes/apps/headlamp/values.yaml
+    - repoURL: "https://github.com/wouterbouvy/home-ops.git"
+      path: kubernetes/apps/headlamp
+      targetRevision: main
+      ref: repo
+  syncPolicy:
+    automated:
+      allowEmpty: true
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true
+      - ServerSideApply=true
+      - PruneLast=true
+      - RespectIgnoreDifferences=true

--- a/kubernetes/argo/clusters/home-ops/kustomization.yaml
+++ b/kubernetes/argo/clusters/home-ops/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - kube-prometheus-stack.yaml
   - loki.yaml
   - alloy.yaml
+  - headlamp.yaml


### PR DESCRIPTION
## Summary
- Deploy Headlamp (chart 0.44.0) with `unsafeUseServiceAccountToken` and chart `cluster-admin` binding
- Authentik ProxyProvider + app + embedded outpost; HTTPRoute to `authentik-server`
- ReferenceGrant for `headlamp` namespace; README auth table row

## Test plan
- [ ] Argo syncs `headlamp` and Authentik blueprints
- [ ] `https://headlamp.home-ops.nl` redirects to Authentik login
- [ ] After login, Headlamp UI shows the cluster
- [ ] Unauthenticated access is blocked


Made with [Cursor](https://cursor.com)