### PR TITLE
Add desktop Headlamp SA kubeconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Thumbs.db
 .cursor/plans/
 # k8s / Omni local credentials
 kubeconfig
+kubeconfig-headlamp-desktop
 talosconfig
 omniconfig
 1password-token

--- a/.mise.toml
+++ b/.mise.toml
@@ -50,6 +50,10 @@ set -euo pipefail
 exec "{{config_root}}/scripts/with-omni-sa.sh" omnictl "$@"
 """
 
+[tasks.headlamp-desktop-kubeconfig]
+description = "Mint gitignored kubeconfig-headlamp-desktop for desktop Headlamp (SA token)"
+run = "{{config_root}}/scripts/headlamp-desktop-kubeconfig.sh"
+
 [tasks.omni-validate]
 description = "Validate home-ops Omni cluster template"
 run = [

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ flowchart TD
 
 - [mise](https://mise.jdx.dev/) (`mise install` from [`.mise.toml`](.mise.toml))
 - [1Password CLI](https://developer.1password.com/docs/cli/) signed in (`op`) when running Omni tasks — `mise run omni-*` / `mise run omnictl` load the **Cursor** service account from vault `k8s-secrets` (item `Omni Cursor service account`) via [`scripts/with-omni-sa.sh`](scripts/with-omni-sa.sh) (other mise commands do not prompt)
-- Local-only files (gitignored): `kubeconfig`, `talosconfig`, `HWIDs.md` (`omniconfig` is optional for personal UI/cli outside mise)
+- Local-only files (gitignored): `kubeconfig`, `kubeconfig-headlamp-desktop`, `talosconfig`, `HWIDs.md` (`omniconfig` is optional for personal UI/cli outside mise)
 
 ## Bootstrap (home-ops)
 
@@ -110,6 +110,8 @@ Public HTTPS UIs are protected by **Authentik** unless a route is explicitly doc
 | `hubble.home-ops.nl` | Authentik **proxy** outpost → Hubble UI |
 | `longhorn.home-ops.nl` | Authentik **proxy** outpost → Longhorn UI |
 | `headlamp.home-ops.nl` | Authentik **proxy** outpost → Headlamp (pod SA → API; shared `cluster-admin`) |
+
+**Desktop Headlamp:** mint a local kubeconfig for the `headlamp-desktop` SA (`cluster-admin`) with `mise run headlamp-desktop-kubeconfig` (writes gitignored `kubeconfig-headlamp-desktop`). Point the desktop app at that file. The file talks to a LAN control-plane API (`https://10.0.8.3:6443` by default; override with `HEADLAMP_DESKTOP_SERVER`) because the Omni proxy does not accept Kubernetes SA tokens.
 
 **Add a new public UI:** prefer app-native OIDC against Authentik; if the app has no SSO, put an Authentik proxy provider in [`kubernetes/apps/authentik/blueprints.yaml`](kubernetes/apps/authentik/blueprints.yaml), attach it to the embedded outpost, and point the HTTPRoute at `authentik-server` in `authentik` (see Hubble/Longhorn + ReferenceGrant). Do **not** publish an unprotected HTTPRoute on the external Gateway.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Public HTTPS UIs are protected by **Authentik** unless a route is explicitly doc
 | `longhorn.home-ops.nl` | Authentik **proxy** outpost → Longhorn UI |
 | `headlamp.home-ops.nl` | Authentik **proxy** outpost → Headlamp (pod SA → API; shared `cluster-admin`) |
 
-**Desktop Headlamp:** mint a local kubeconfig for the `headlamp-desktop` SA (`cluster-admin`) with `mise run headlamp-desktop-kubeconfig` (writes gitignored `kubeconfig-headlamp-desktop`). Point the desktop app at that file. The file talks to a LAN control-plane API (`https://10.0.8.3:6443` by default; override with `HEADLAMP_DESKTOP_SERVER`) because the Omni proxy does not accept Kubernetes SA tokens.
+**Desktop Headlamp:** mint a local kubeconfig for the `headlamp-desktop` SA (`cluster-admin`) with `mise run headlamp-desktop-kubeconfig` (writes gitignored `kubeconfig-headlamp-desktop`). Point the desktop app at that file. The file talks to the Talos L2 Kubernetes API VIP (`https://10.0.8.6:6443` by default; override with `HEADLAMP_DESKTOP_SERVER`) because the Omni proxy does not accept Kubernetes SA tokens.
 
 **Add a new public UI:** prefer app-native OIDC against Authentik; if the app has no SSO, put an Authentik proxy provider in [`kubernetes/apps/authentik/blueprints.yaml`](kubernetes/apps/authentik/blueprints.yaml), attach it to the embedded outpost, and point the HTTPRoute at `authentik-server` in `authentik` (see Hubble/Longhorn + ReferenceGrant). Do **not** publish an unprotected HTTPRoute on the external Gateway.
 

--- a/kubernetes/apps/headlamp/desktop-sa.yaml
+++ b/kubernetes/apps/headlamp/desktop-sa.yaml
@@ -1,0 +1,30 @@
+---
+# Dedicated SA for Headlamp running on a desktop (local kubeconfig), not the in-cluster UI.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp-desktop
+  namespace: headlamp
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-desktop
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: headlamp-desktop
+    namespace: headlamp
+---
+# Long-lived token for local kubeconfig minting (K8s 1.24+ does not auto-create SA secrets).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: headlamp-desktop-token
+  namespace: headlamp
+  annotations:
+    kubernetes.io/service-account.name: headlamp-desktop
+type: kubernetes.io/service-account-token

--- a/kubernetes/apps/headlamp/kustomization.yaml
+++ b/kubernetes/apps/headlamp/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./httproute.yaml
+  - ./desktop-sa.yaml

--- a/scripts/headlamp-desktop-kubeconfig.sh
+++ b/scripts/headlamp-desktop-kubeconfig.sh
@@ -3,7 +3,7 @@
 #
 # Omni's public kube-apiserver proxy (omni.k5s.dev) expects Omni OIDC, not Kubernetes SA
 # tokens. This kubeconfig therefore targets a control-plane kube-apiserver on the LAN
-# (default https://10.0.8.3:6443). Override with HEADLAMP_DESKTOP_SERVER if needed.
+# (default https://10.0.8.6:6443 Talos L2 VIP). Override with HEADLAMP_DESKTOP_SERVER if needed.
 #
 # Requires: existing cluster access via $KUBECONFIG (repo kubeconfig), SA already present.
 set -euo pipefail
@@ -14,8 +14,8 @@ NS=headlamp
 SA=headlamp-desktop
 SECRET=headlamp-desktop-token
 CONTEXT_NAME="${HEADLAMP_DESKTOP_CONTEXT:-headlamp-desktop}"
-# Direct kube-apiserver (LAN). Not the Omni proxy URL from the repo kubeconfig.
-SERVER="${HEADLAMP_DESKTOP_SERVER:-https://10.0.8.3:6443}"
+# Talos L2 VIP on eno1.8 (HA across control planes). Not the Omni proxy URL.
+SERVER="${HEADLAMP_DESKTOP_SERVER:-https://10.0.8.6:6443}"
 
 export KUBECONFIG="${KUBECONFIG:-${ROOT}/kubeconfig}"
 

--- a/scripts/headlamp-desktop-kubeconfig.sh
+++ b/scripts/headlamp-desktop-kubeconfig.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Mint a gitignored kubeconfig for desktop Headlamp using the headlamp-desktop SA token.
+#
+# Omni's public kube-apiserver proxy (omni.k5s.dev) expects Omni OIDC, not Kubernetes SA
+# tokens. This kubeconfig therefore targets a control-plane kube-apiserver on the LAN
+# (default https://10.0.8.3:6443). Override with HEADLAMP_DESKTOP_SERVER if needed.
+#
+# Requires: existing cluster access via $KUBECONFIG (repo kubeconfig), SA already present.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="${HEADLAMP_DESKTOP_KUBECONFIG:-${ROOT}/kubeconfig-headlamp-desktop}"
+NS=headlamp
+SA=headlamp-desktop
+SECRET=headlamp-desktop-token
+CONTEXT_NAME="${HEADLAMP_DESKTOP_CONTEXT:-headlamp-desktop}"
+# Direct kube-apiserver (LAN). Not the Omni proxy URL from the repo kubeconfig.
+SERVER="${HEADLAMP_DESKTOP_SERVER:-https://10.0.8.3:6443}"
+
+export KUBECONFIG="${KUBECONFIG:-${ROOT}/kubeconfig}"
+
+if [[ ! -f "${KUBECONFIG}" ]]; then
+  echo "headlamp-desktop-kubeconfig: missing ${KUBECONFIG} (run mise run omni-sync first)" >&2
+  exit 1
+fi
+
+if ! kubectl get secret -n "${NS}" "${SECRET}" >/dev/null 2>&1; then
+  echo "headlamp-desktop-kubeconfig: secret ${NS}/${SECRET} not found — wait for Argo to sync headlamp" >&2
+  exit 1
+fi
+
+echo "Waiting for token in ${NS}/${SECRET}..."
+TOKEN=""
+CA=""
+for _ in $(seq 1 60); do
+  TOKEN="$(kubectl get secret -n "${NS}" "${SECRET}" -o jsonpath='{.data.token}' 2>/dev/null || true)"
+  CA="$(kubectl get secret -n "${NS}" "${SECRET}" -o jsonpath='{.data.ca\.crt}' 2>/dev/null || true)"
+  if [[ -n "${TOKEN}" && -n "${CA}" ]]; then
+    break
+  fi
+  sleep 2
+done
+
+if [[ -z "${TOKEN}" || -z "${CA}" ]]; then
+  echo "headlamp-desktop-kubeconfig: timed out waiting for SA token/CA" >&2
+  exit 1
+fi
+
+TOKEN_PLAIN="$(printf '%s' "${TOKEN}" | base64 --decode)"
+CA_PLAIN="$(printf '%s' "${CA}" | base64 --decode)"
+
+umask 077
+rm -f "${OUT}"
+touch "${OUT}"
+chmod 600 "${OUT}"
+
+kubectl config --kubeconfig="${OUT}" set-cluster home-ops \
+  --server="${SERVER}" \
+  --certificate-authority=<(printf '%s' "${CA_PLAIN}") \
+  --embed-certs=true
+kubectl config --kubeconfig="${OUT}" set-credentials "${SA}" --token="${TOKEN_PLAIN}"
+kubectl config --kubeconfig="${OUT}" set-context "${CONTEXT_NAME}" --cluster=home-ops --user="${SA}"
+kubectl config --kubeconfig="${OUT}" use-context "${CONTEXT_NAME}"
+
+echo "Wrote ${OUT} (context ${CONTEXT_NAME}, server ${SERVER}). Point desktop Headlamp at this kubeconfig."


### PR DESCRIPTION
## Summary
- Add `headlamp-desktop` ServiceAccount + `cluster-admin` binding + long-lived token Secret
- Add `mise run headlamp-desktop-kubeconfig` to mint gitignored `kubeconfig-headlamp-desktop`
- Target LAN kube-apiserver (`https://10.0.8.3:6443` by default); Omni proxy does not accept Kubernetes SA tokens

## Test plan
- [x] `mise run headlamp-desktop-kubeconfig` writes `kubeconfig-headlamp-desktop` (gitignored)
- [x] `KUBECONFIG=./kubeconfig-headlamp-desktop kubectl get nodes` succeeds
- [ ] Point desktop Headlamp at `kubeconfig-headlamp-desktop` and browse the cluster
- [ ] After merge, Argo keeps the SA/Secret in sync


Made with [Cursor](https://cursor.com)