### PR TITLE
Add Talos L2 VIP 10.0.8.6 on eno1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Full mgmt bootstrap and testing still need Omni machine wiring later. When ready
 | Item | Value |
 |------|--------|
 | Public domain | `home-ops.nl` |
+| Kubernetes API VIP (Talos L2) | `10.0.8.6` (`eno1.8`; do not use as `talosconfig` endpoint) |
 | External Gateway VIP | `10.0.8.120` |
 | Internal Gateway VIP | `10.0.8.110` |
 | Example hosts | `authentik.home-ops.nl`, `argocd.home-ops.nl`, `longhorn.home-ops.nl`, `grafana.home-ops.nl`, `hubble.home-ops.nl`, `headlamp.home-ops.nl` |

--- a/kubernetes/bootstrap/talos/omni-home-ops.yaml
+++ b/kubernetes/bootstrap/talos/omni-home-ops.yaml
@@ -46,6 +46,7 @@ patches:
   - file: patches/base/controlplane/allow-scheduling-on-cp.yaml
   - file: patches/overlays/home-ops/controlplane/disk-encryption.yaml
   - file: patches/overlays/home-ops/controlplane/NIC-config.yaml
+  - file: patches/overlays/home-ops/controlplane/layer2-vip.yaml
   - file: patches/overlays/home-ops/controlplane/longhorn-uservolume.yaml
   # - file: patches/overlays/home-ops/controlplane/longhorn-v2-params.yaml
 ---

--- a/kubernetes/bootstrap/talos/patches/README.md
+++ b/kubernetes/bootstrap/talos/patches/README.md
@@ -6,7 +6,7 @@ Patches referenced by Omni cluster templates
 Layout:
 
 - `base/` — shared across clusters (`global/` for all machines, `controlplane/` for control planes)
-- `overlays/<cluster>/` — cluster-specific patches (NICs, disks, encryption, user volumes)
+- `overlays/<cluster>/` — cluster-specific patches (NICs, disks, encryption, user volumes, L2 VIP)
 
 Omni applies the listed `patches[].file` entries from each template; there is no
 talhelper in this repo.

--- a/kubernetes/bootstrap/talos/patches/overlays/home-ops/controlplane/layer2-vip.yaml
+++ b/kubernetes/bootstrap/talos/patches/overlays/home-ops/controlplane/layer2-vip.yaml
@@ -1,0 +1,6 @@
+# Shared L2 VIP for Kubernetes API HA on VLAN 8 (same L2 as eno1.8).
+# etcd elects which control plane owns the address; do not use as talosconfig endpoint.
+apiVersion: v1alpha1
+kind: Layer2VIPConfig
+name: 10.0.8.6
+link: eno1.8


### PR DESCRIPTION
## Summary
- Add `Layer2VIPConfig` for `10.0.8.6` on link `eno1.8` (control-plane overlay)
- Wire the patch into the home-ops Omni ControlPlane template
- Document the Kubernetes API VIP in the README (do not use as `talosconfig` endpoint)

## Test plan
- [x] `mise run omni-validate` passes
- [ ] `mise run omni-sync` applies the VIP
- [ ] One control plane shows `10.0.8.6` on `eno1.8`; `curl -k https://10.0.8.6:6443/livez` succeeds
- [ ] After a CP reboot, VIP moves to another node
- [ ] (optional) Point desktop Headlamp kubeconfig at `https://10.0.8.6:6443`


Made with [Cursor](https://cursor.com)