### PR TITLE
Fix cloudflare-tunnel ExternalSecret sync

### DIFF
--- a/kubernetes/apps/cloudflare-tunnel/apply-job.yaml
+++ b/kubernetes/apps/cloudflare-tunnel/apply-job.yaml
@@ -50,7 +50,7 @@ spec:
             - /bin/sh
             - -ec
             - |
-              apk add --no-cache --quiet curl jq yq
+              apk add --no-cache --quiet bash curl jq yq
               exec /scripts/cloudflare-tunnel-apply.sh
           volumeMounts:
             - name: ingress

--- a/kubernetes/apps/cloudflare-tunnel/externalsecret.yaml
+++ b/kubernetes/apps/cloudflare-tunnel/externalsecret.yaml
@@ -7,6 +7,9 @@
 #   ZONE_ID      — Zone ID for home-ops.nl
 # API token is reused from item "cloudflare" / CLOUDFLARE_DNS_TOKEN (cert-manager).
 # That token needs Zone DNS Edit and Account Cloudflare Tunnel Edit.
+#
+# Use dataFrom+template (same as cert-manager). onepasswordSDK rejects
+# remoteRef key+property style ("op://vault/item/field" required for data[]).
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -22,24 +25,16 @@ spec:
   target:
     name: cloudflare-tunnel
     creationPolicy: Owner
-  data:
-    - secretKey: TUNNEL_TOKEN
-      remoteRef:
+    template:
+      engineVersion: v2
+      data:
+        TUNNEL_TOKEN: "{{ .TUNNEL_TOKEN }}"
+        TUNNEL_ID: "{{ .TUNNEL_ID }}"
+        ACCOUNT_ID: "{{ .ACCOUNT_ID }}"
+        ZONE_ID: "{{ .ZONE_ID }}"
+        CLOUDFLARE_API_TOKEN: "{{ .CLOUDFLARE_DNS_TOKEN }}"
+  dataFrom:
+    - extract:
         key: cloudflare-tunnel
-        property: TUNNEL_TOKEN
-    - secretKey: TUNNEL_ID
-      remoteRef:
-        key: cloudflare-tunnel
-        property: TUNNEL_ID
-    - secretKey: ACCOUNT_ID
-      remoteRef:
-        key: cloudflare-tunnel
-        property: ACCOUNT_ID
-    - secretKey: ZONE_ID
-      remoteRef:
-        key: cloudflare-tunnel
-        property: ZONE_ID
-    - secretKey: CLOUDFLARE_API_TOKEN
-      remoteRef:
+    - extract:
         key: cloudflare
-        property: CLOUDFLARE_DNS_TOKEN


### PR DESCRIPTION
## Summary
- ExternalSecret was using `spec.data` remoteRef `key` + `property`, which the `onepasswordSDK` provider rejects (`op://vault/item/field` required).
- Sync failed, so Secret only had `TUNNEL_TOKEN` and the PostSync Job hit `couldn't find key ACCOUNT_ID`.
- Switch to `dataFrom` extract + template (same pattern as cert-manager / Authentik).

## Test plan
- [x] ExternalSecret Ready; Secret has TUNNEL_TOKEN, TUNNEL_ID, ACCOUNT_ID, ZONE_ID, CLOUDFLARE_API_TOKEN
- [ ] PostSync / apply Job Completes
- [ ] CI green


Made with [Cursor](https://cursor.com)