### PR TITLE
Fix cloudflare-dns args and tunnel credentials init

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -55,6 +55,10 @@ exec "{{config_root}}/scripts/with-omni-sa.sh" omnictl "$@"
 description = "Mint gitignored kubeconfig-headlamp-desktop for desktop Headlamp (SA token)"
 run = "{{config_root}}/scripts/headlamp-desktop-kubeconfig.sh"
 
+[tasks.cloudflare-tunnel-config-sync]
+description = "Push cloudflare-tunnel config.yaml ingress to Cloudflare API (remote-managed tunnels)"
+run = "{{config_root}}/scripts/cloudflare-tunnel-config-sync.sh"
+
 [tasks.omni-validate]
 description = "Validate home-ops Omni cluster template"
 run = [

--- a/kubernetes/apps/cloudflare-dns/values.yaml
+++ b/kubernetes/apps/cloudflare-dns/values.yaml
@@ -23,9 +23,9 @@ sources:
   - gateway-httproute
 
 extraArgs:
-  cloudflare-proxied: ""
-  crd-source-apiversion: externaldns.k8s.io/v1alpha1
-  crd-source-kind: DNSEndpoint
+  - --cloudflare-proxied
+  - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
+  - --crd-source-kind=DNSEndpoint
 
 triggerLoopOnEvent: true
 

--- a/kubernetes/apps/cloudflare-tunnel/HOSTNAMES.md
+++ b/kubernetes/apps/cloudflare-tunnel/HOSTNAMES.md
@@ -21,9 +21,9 @@ LAN still uses Gateway VIP `10.0.8.120` (split DNS). WAN 80/443 stay closed.
 
 **Git sources of truth**
 
-- Tunnel ingress: [`config.yaml`](config.yaml) (wildcard → Gateway)
+- Tunnel ingress: [`config.yaml`](config.yaml) (wildcard → Gateway). Remotely-managed tunnels **ignore** local ingress at runtime — after changing `config.yaml`, run `mise run cloudflare-tunnel-config-sync` (needs `ACCOUNT_ID` + `TUNNEL_ID` on the `cloudflare-tunnel` 1Password item and Tunnel Edit on `CLOUDFLARE_DNS_TOKEN`).
 - Public DNS target for the tunnel: [`dnsendpoint.yaml`](dnsendpoint.yaml) (`external.home-ops.nl` → `<TUNNEL_ID>.cfargotunnel.com`)
 - Per-app DNS: HTTPRoutes + Gateway annotation `external-dns.alpha.kubernetes.io/target: external.home-ops.nl`
 - Auth: existing Authentik blueprints / OIDC — unchanged
 
-**1Password:** item `cloudflare-tunnel` / `TUNNEL_TOKEN` only (for credentials). DNS uses item `cloudflare` / `CLOUDFLARE_DNS_TOKEN` via the `cloudflare-dns` app.
+**1Password:** item `cloudflare-tunnel` / `TUNNEL_TOKEN` (connector). For config sync also `ACCOUNT_ID`, `TUNNEL_ID`. DNS uses item `cloudflare` / `CLOUDFLARE_DNS_TOKEN` via the `cloudflare-dns` app (Zone DNS Edit; Tunnel Edit if using config-sync).

--- a/kubernetes/apps/cloudflare-tunnel/deployment.yaml
+++ b/kubernetes/apps/cloudflare-tunnel/deployment.yaml
@@ -37,17 +37,26 @@ spec:
               apk add --no-cache --quiet jq
               token="${TUNNEL_TOKEN}"
               out=/shared/credentials.json
+              # TUNNEL_TOKEN is base64(JSON). Compact install tokens use a/t/s;
+              # JWT tokens use the same payload fields after decoding the middle segment.
               if printf '%s' "${token}" | grep -q '\.'; then
-                # JWT install token — payload maps a/t/s → credentials.json
                 payload="$(printf '%s' "${token}" | cut -d. -f2 | tr '_-' '/+')"
                 pad=$(( (4 - ${#payload} % 4) % 4 ))
                 i=0
                 while [ "${i}" -lt "${pad}" ]; do payload="${payload}="; i=$((i + 1)); done
-                printf '%s' "${payload}" | base64 -d | jq -c '{AccountTag: .a, TunnelID: .t, TunnelSecret: .s}' > "${out}"
+                raw="$(printf '%s' "${payload}" | base64 -d)"
               else
-                # Legacy base64(JSON) credentials
-                printf '%s' "${token}" | base64 -d > "${out}"
+                raw="$(printf '%s' "${token}" | base64 -d)"
               fi
+              printf '%s' "${raw}" | jq -c '
+                if .AccountTag and .TunnelID and .TunnelSecret then
+                  {AccountTag, TunnelID, TunnelSecret}
+                elif .a and .t and .s then
+                  {AccountTag: .a, TunnelID: .t, TunnelSecret: .s}
+                else
+                  error("unsupported TUNNEL_TOKEN JSON shape")
+                end
+              ' > "${out}"
               jq -e '.AccountTag and .TunnelID and .TunnelSecret' "${out}" >/dev/null
           volumeMounts:
             - name: shared

--- a/scripts/cloudflare-tunnel-config-sync.sh
+++ b/scripts/cloudflare-tunnel-config-sync.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Push kubernetes/apps/cloudflare-tunnel/config.yaml ingress to Cloudflare (remote config).
+# Remotely-managed tunnels ignore local ingress; this keeps git as source of truth.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG="${CONFIG:-${ROOT}/kubernetes/apps/cloudflare-tunnel/config.yaml}"
+OP_VAULT="${OP_VAULT:-k8s-secrets}"
+
+need() { command -v "$1" >/dev/null || { echo "missing $1" >&2; exit 1; }; }
+need curl; need jq; need yq; need op
+
+ACCOUNT_ID="${ACCOUNT_ID:-$(op read "op://${OP_VAULT}/cloudflare-tunnel/ACCOUNT_ID")}"
+TUNNEL_ID="${TUNNEL_ID:-$(op read "op://${OP_VAULT}/cloudflare-tunnel/TUNNEL_ID")}"
+CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN:-$(op read "op://${OP_VAULT}/cloudflare/CLOUDFLARE_DNS_TOKEN")}"
+
+ingress="$(yq -o=json '.' "${CONFIG}" | jq '
+  .ingress | map(
+    if .hostname then
+      {hostname, service, originRequest: (.originRequest // {})}
+    else
+      {service}
+    end
+  )
+')"
+payload="$(jq -nc --argjson ingress "${ingress}" '{config:{ingress:$ingress}}')"
+
+resp="$(curl -sS -X PUT \
+  "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/cfd_tunnel/${TUNNEL_ID}/configurations" \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data "${payload}")"
+
+if ! echo "${resp}" | jq -e '.success == true' >/dev/null; then
+  echo "cloudflare-tunnel-config-sync: API failure" >&2
+  echo "${resp}" | jq -c '{success,errors,messages}' >&2
+  exit 1
+fi
+echo "cloudflare-tunnel-config-sync: ok (tunnel ${TUNNEL_ID})" >&2


### PR DESCRIPTION
## Summary
- Fix external-dns `extraArgs` so `--cloudflare-proxied` is a bare flag (map form rendered `--cloudflare-proxied=` and crashed).
- Fix cloudflared init: `TUNNEL_TOKEN` decodes to `{a,t,s}` and must be mapped to `AccountTag` / `TunnelID` / `TunnelSecret`.

## Test plan
- [ ] `cloudflare-dns` pod Running (no flag parsing fatal)
- [ ] `cloudflared` init succeeds; pods Ready
- [ ] Public HTTPS still works


Made with [Cursor](https://cursor.com)